### PR TITLE
feat(site): PostHog web analytics + session replay

### DIFF
--- a/site/analytics.js
+++ b/site/analytics.js
@@ -1,0 +1,19 @@
+// PostHog — product analytics, web analytics, autocapture + session replay
+// for haynoi.com. Single source loaded by every page.
+!function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Ie Ts Ms Ee Es Rs capture Ge calculateEventProperties Os register register_once register_for_session unregister unregister_for_session Ps getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey canRenderSurveyAsync identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty Ds Fs createPersonProfile Ls Ws opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing Cs debug I As getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+
+posthog.init("phc_rxVoY3pgniT45EsAX55HenKPB6MPDPGzPS3Xx8aMW7N6", {
+  api_host: "https://us.i.posthog.com",
+  ui_host: "https://us.posthog.com",
+  defaults: "2025-05-24",          // history-based pageview + pageleave
+  person_profiles: "identified_only",
+  autocapture: true,
+  capture_pageview: true,
+  capture_pageleave: true,
+});
+
+// Verification event — confirms the install is live in PostHog Activity.
+posthog.capture("haynoi_site_view", {
+  page: location.pathname,
+  referrer: document.referrer || null,
+});

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -22,6 +22,9 @@
     .release-dl { margin-top: 1.4rem; }
     .release-dl a { text-decoration: underline; }
   </style>
+
+  <!-- PostHog analytics -->
+  <script src="/analytics.js"></script>
 </head>
 <body>
 <nav>

--- a/site/index.html
+++ b/site/index.html
@@ -22,6 +22,9 @@
   <link rel="icon" href="icon.png" type="image/png" />
   <link rel="apple-touch-icon" href="icon.png" />
   <link rel="stylesheet" href="style.css" />
+
+  <!-- PostHog analytics -->
+  <script src="/analytics.js"></script>
 </head>
 <body>
 

--- a/site/thanks/index.html
+++ b/site/thanks/index.html
@@ -49,6 +49,9 @@
       background: linear-gradient(160deg,#9DB8E8,#5B7FC7); display:flex;
       align-items:center; justify-content:center; color:#fff; font-size:1.4rem; }
   </style>
+
+  <!-- PostHog analytics -->
+  <script src="/analytics.js"></script>
 </head>
 <body>
 <nav>


### PR DESCRIPTION
Adds PostHog to the haynoi.com landing site (project 446617).

- `site/analytics.js` — official PostHog snippet + init (pageview, pageleave, autocapture, web vitals) + a `haynoi_site_view` verify event
- Wired into `index.html`, `changelog/`, `thanks/`

Cherry-picked clean off `main` so it carries **only** the PostHog change — no obsidian-relaunch work.

Verified: ingestion live (test event landed in ClickHouse); a real browser fetches `array.js`, loads project config, and POSTs to `/e` (Chrome netlog).

Note: site is deployed to Cloudflare Pages via `wrangler pages deploy` (not git-connected), so this merge does not auto-deploy — deploy is a separate step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)