### PR TITLE
Release 0.3.7 — Haynoi Pro live: Stripe checkout end-to-end

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.7] - 2026-07-05
+
+### Added
+- **Haynoi Pro is live.** Unlimited dictation, all 4 modes, priority
+  transcription — $14.99/month or $125.88/year. Upgrade in
+  Settings → Plans & Billing; payment runs through Stripe in your browser
+  and the app unlocks within seconds. Manage or cancel anytime.
+
+### Fixed
+- Usage analytics events now actually reach our dashboard (a
+  misconfigured key silently dropped them — still counts and timings
+  only, never your words).
+
 ## [0.3.6] - 2026-07-04
 
 ### Added

--- a/Sources/Haynoi/Settings/SettingsView.swift
+++ b/Sources/Haynoi/Settings/SettingsView.swift
@@ -704,7 +704,7 @@ private struct DictionaryEditor: View {
 
 private struct BillingTab: View {
     @State private var billingPeriod: BillingPeriod = .annual
-    @State private var promoCode = ""
+    @ObservedObject private var billing = BillingManager.shared
     @Environment(\.colorScheme) private var scheme
 
     enum BillingPeriod { case monthly, annual }
@@ -717,9 +717,9 @@ private struct BillingTab: View {
         VStack(alignment: .leading, spacing: C.s5) {
             currentPlanSection
             upgradeSection
-            promoSection
             teamSection
         }
+        .task { await billing.refresh() }
     }
 
     // MARK: Current Plan
@@ -729,33 +729,74 @@ private struct BillingTab: View {
             SectionEyebrow(title: "Current Plan")
 
             SettingsCard {
-                SettingsRow(showDivider: false) {
+                SettingsRow(showDivider: billing.isPro) {
                     HStack(spacing: C.s3) {
                         VStack(alignment: .leading, spacing: 3) {
-                            Text("Free plan")
+                            Text(billing.isPro ? "Pro plan" : "Free plan")
                                 .font(.system(size: 13, weight: .semibold))
                                 .foregroundStyle(Color.obsidianLabel(for: scheme))
-                            Text("5,000 words / week  ·  Auto-detect language  ·  Normal mode only")
+                            Text(currentPlanDetail)
                                 .font(.system(size: 11))
                                 .foregroundStyle(Color.obsidianLabel3(for: scheme))
                         }
                         Spacer()
-                        // Free badge
-                        Text("FREE")
+                        Text(billing.isPro ? "PRO" : "FREE")
                             .font(.system(size: 10, weight: .semibold))
                             .kerning(0.4)
-                            .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                            .foregroundStyle(
+                                billing.isPro
+                                    ? Color.accentOnLight
+                                    : Color.obsidianLabel3(for: scheme))
                             .padding(.horizontal, 8)
                             .padding(.vertical, 3)
-                            .background(Color.obsidianHover(for: scheme))
+                            .background(
+                                billing.isPro
+                                    ? Color.accent.opacity(0.08)
+                                    : Color.obsidianHover(for: scheme))
                             .overlay(
-                                Capsule().stroke(Color.obsidianDivider(for: scheme), lineWidth: 1)
+                                Capsule().stroke(
+                                    billing.isPro
+                                        ? Color.accent.opacity(0.35)
+                                        : Color.obsidianDivider(for: scheme),
+                                    lineWidth: 1)
                             )
                             .clipShape(Capsule())
                     }
                 }
+                if billing.isPro {
+                    SettingsRow(showDivider: false) {
+                        HStack {
+                            Text("Payment method, invoices, cancel")
+                                .font(.system(size: 11))
+                                .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                            Spacer()
+                            Button("Manage subscription") {
+                                Task { await billing.openPortal() }
+                            }
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(Color.obsidianAccent(for: scheme))
+                            .buttonStyle(.plain)
+                        }
+                    }
+                }
             }
         }
+    }
+
+    private var currentPlanDetail: String {
+        guard billing.isPro else {
+            return "5,000 words / week  ·  Auto-detect language  ·  Normal mode only"
+        }
+        var detail = "Unlimited words  ·  All modes"
+        if let sub = billing.subscription {
+            let date = Date(timeIntervalSince1970: sub.currentPeriodEnd / 1000)
+            let df = DateFormatter()
+            df.dateStyle = .medium
+            detail += sub.cancelAtPeriodEnd
+                ? "  ·  Ends \(df.string(from: date))"
+                : "  ·  Renews \(df.string(from: date))"
+        }
+        return detail
     }
 
     // MARK: Upgrade
@@ -890,22 +931,27 @@ private struct BillingTab: View {
             .clipShape(Capsule())
             .padding(.bottom, C.s2)
 
-            // Coming soon — paid tier ships in a later phase. No price shown
-            // yet; everyone is on Free for now.
-            Text("Coming soon")
-                .font(.system(.title3, design: .monospaced).weight(.regular))
-                .foregroundStyle(Color.obsidianLabel2(for: scheme))
-                .padding(.bottom, 2)
+            // Price — follows the Monthly/Annual toggle
+            HStack(alignment: .firstTextBaseline, spacing: 4) {
+                Text(billingPeriod == .monthly ? monthlyPrice : annualMonthlyPrice)
+                    .font(.system(.title, design: .monospaced).weight(.regular))
+                    .foregroundStyle(Color.obsidianLabel(for: scheme))
+                Text("/ month")
+                    .font(.system(size: 12))
+                    .foregroundStyle(Color.obsidianLabel3(for: scheme))
+            }
+            .padding(.bottom, 2)
 
-            Text("Haynoi is free while we build. Pro pricing arrives later.")
-                .font(.system(size: 10.5))
+            Text(billingPeriod == .monthly
+                 ? "Billed monthly. Cancel anytime."
+                 : "Billed \(annualTotalPrice) / year. Cancel anytime.")
+                .font(.system(size: 10.5, design: .monospaced))
                 .foregroundStyle(Color.obsidianLabel3(for: scheme))
                 .padding(.bottom, C.s3)
 
             Divider().background(Color.obsidianDivider(for: scheme))
                 .padding(.bottom, C.s3)
 
-            // What Pro will include (preview only).
             PlanFeature(text: "Unlimited dictation", included: true)
             PlanFeature(text: "All 4 modes", included: true)
             PlanFeature(text: "Priority transcription", included: true)
@@ -913,14 +959,7 @@ private struct BillingTab: View {
 
             Spacer(minLength: C.s5)
 
-            // Disabled placeholder CTA — no checkout yet.
-            Text("Coming soon")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(Color.obsidianLabel3(for: scheme))
-                .frame(maxWidth: .infinity)
-                .padding(.vertical, 10)
-                .background(Color.obsidianSubtle(for: scheme))
-                .clipShape(RoundedRectangle(cornerRadius: C.rSM))
+            proCTA
         }
         .padding(C.s4)
         .frame(maxWidth: .infinity, alignment: .leading)
@@ -930,40 +969,57 @@ private struct BillingTab: View {
                 .stroke(Color.obsidianDivider(for: scheme), lineWidth: 1)
         )
         .clipShape(RoundedRectangle(cornerRadius: C.rLG))
-        // Dimmed: this tier isn't live yet.
-        .opacity(0.6)
     }
 
-    // MARK: Promo Code
-
-    private var promoSection: some View {
-        VStack(alignment: .leading, spacing: C.s2) {
-            SectionEyebrow(title: "Promo Code")
-
-            SettingsCard {
-                SettingsRow(showDivider: false) {
-                    HStack(spacing: C.s2) {
-                        Image(systemName: "tag")
-                            .font(.system(size: 13))
-                            .foregroundStyle(Color.obsidianLabel3(for: scheme))
-
-                        TextField("Enter promo code…", text: $promoCode)
-                            .font(.system(size: 12))
-                            .foregroundStyle(Color.obsidianLabel(for: scheme))
-                            .textFieldStyle(.plain)
-
-                        Button("Apply") {
-                            // Wire to real endpoint later
-                        }
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(
-                            promoCode.isEmpty
-                                ? Color.obsidianLabel3(for: scheme)
-                                : Color.obsidianAccent(for: scheme)
-                        )
-                        .buttonStyle(.plain)
-                        .disabled(promoCode.isEmpty)
+    @ViewBuilder
+    private var proCTA: some View {
+        if billing.isPro {
+            Text("Current plan")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 10)
+                .overlay(
+                    RoundedRectangle(cornerRadius: C.rSM)
+                        .stroke(Color.obsidianDivider(for: scheme), lineWidth: 1)
+                )
+        } else if billing.awaitingCheckout {
+            HStack(spacing: 6) {
+                ProgressView().controlSize(.small)
+                Text("Waiting for payment…")
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(Color.obsidianLabel3(for: scheme))
+            }
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 10)
+            .background(Color.obsidianSubtle(for: scheme))
+            .clipShape(RoundedRectangle(cornerRadius: C.rSM))
+        } else {
+            VStack(spacing: 4) {
+                Button {
+                    Analytics.capture("upgrade_clicked", [
+                        "cycle": billingPeriod == .monthly ? "monthly" : "annual",
+                    ])
+                    Task {
+                        await billing.startCheckout(
+                            cycle: billingPeriod == .monthly ? "monthly" : "annual")
                     }
+                } label: {
+                    Text("Upgrade to Pro")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundStyle(.white)
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 10)
+                        .background(Color.accent)
+                        .clipShape(RoundedRectangle(cornerRadius: C.rSM))
+                }
+                .buttonStyle(.plain)
+
+                if let err = billing.lastError {
+                    Text(err)
+                        .font(.system(size: 10.5))
+                        .foregroundStyle(scheme == .dark ? Color.obsidianDarkError : Color.obsidianError)
+                        .lineLimit(2)
                 }
             }
         }

--- a/Sources/Haynoi/System/BillingManager.swift
+++ b/Sources/Haynoi/System/BillingManager.swift
@@ -1,0 +1,129 @@
+import AppKit
+import Foundation
+
+// MARK: - BillingManager
+//
+// Stripe subscription state + checkout flow via haynoi-server /v1/billing/*.
+// Checkout happens in the browser (Stripe Checkout); the server webhook flips
+// the tier in D1, so after opening the URL we poll /v1/billing/subscription
+// until the upgrade lands (or the user gives up and the poll times out).
+
+@MainActor
+final class BillingManager: ObservableObject {
+    static let shared = BillingManager()
+
+    struct Subscription: Decodable {
+        let tier: String
+        let cycle: String
+        let status: String
+        let currentPeriodEnd: Double  // epoch ms
+        let cancelAtPeriodEnd: Bool
+    }
+
+    @Published private(set) var tier: String = "free"
+    @Published private(set) var subscription: Subscription?
+    /// True from "Upgrade" click until the webhook lands or polling gives up.
+    @Published private(set) var awaitingCheckout = false
+    @Published var lastError: String?
+
+    var isPro: Bool { tier == "pro" || tier == "max" }
+
+    private init() {}
+
+    private struct SubscriptionResponse: Decodable {
+        let ok: Bool
+        let tier: String
+        let subscription: Subscription?
+    }
+
+    private struct CheckoutResponse: Decodable {
+        let ok: Bool
+        let url: String
+    }
+
+    private struct APIError: Decodable {
+        struct Body: Decodable { let code: String; let message: String }
+        let error: Body
+    }
+
+    func refresh() async {
+        guard let token = HaynoiAuth.currentToken else { return }
+        do {
+            let resp: SubscriptionResponse = try await request(
+                "GET", "/v1/billing/subscription", token: token)
+            tier = resp.tier
+            subscription = resp.subscription
+        } catch {
+            NSLog("[Haynoi] BillingManager.refresh: %@", error.localizedDescription)
+        }
+    }
+
+    /// Create a Stripe Checkout session, open it in the browser, then poll
+    /// for the webhook-driven tier flip (every 3s, up to 10 minutes).
+    func startCheckout(cycle: String) async {
+        guard let token = HaynoiAuth.currentToken else { return }
+        lastError = nil
+        do {
+            let resp: CheckoutResponse = try await request(
+                "POST", "/v1/billing/checkout", token: token,
+                body: ["plan": "pro", "cycle": cycle])
+            guard let url = URL(string: resp.url) else { return }
+            NSWorkspace.shared.open(url)
+            awaitingCheckout = true
+            for _ in 0..<200 where awaitingCheckout {
+                try await Task.sleep(nanoseconds: 3_000_000_000)
+                await refresh()
+                if isPro {
+                    awaitingCheckout = false
+                    BalanceManager.shared.refresh()
+                    Analytics.capture("upgrade_completed", ["cycle": cycle])
+                }
+            }
+            awaitingCheckout = false
+        } catch {
+            awaitingCheckout = false
+            lastError = error.localizedDescription
+            NSLog("[Haynoi] BillingManager.startCheckout: %@", error.localizedDescription)
+        }
+    }
+
+    /// Open the Stripe Customer Portal (manage plan, payment method, invoices).
+    func openPortal() async {
+        guard let token = HaynoiAuth.currentToken else { return }
+        do {
+            let resp: CheckoutResponse = try await request(
+                "POST", "/v1/billing/portal", token: token, body: [:])
+            if let url = URL(string: resp.url) { NSWorkspace.shared.open(url) }
+        } catch {
+            lastError = error.localizedDescription
+            NSLog("[Haynoi] BillingManager.openPortal: %@", error.localizedDescription)
+        }
+    }
+
+    // MARK: - HTTP
+
+    private func request<T: Decodable>(
+        _ method: String, _ path: String, token: String,
+        body: [String: String]? = nil
+    ) async throws -> T {
+        var req = URLRequest(url: URL(string: "\(HaynoiAuth.baseURL)\(path)")!)
+        req.httpMethod = method
+        req.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        req.timeoutInterval = 15
+        if let body {
+            req.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            req.httpBody = try JSONEncoder().encode(body)
+        }
+        let (data, response) = try await URLSession.shared.data(for: req)
+        guard let http = response as? HTTPURLResponse else { throw URLError(.badServerResponse) }
+        guard http.statusCode == 200 else {
+            if let api = try? JSONDecoder().decode(APIError.self, from: data) {
+                throw NSError(
+                    domain: "HaynoiBilling", code: http.statusCode,
+                    userInfo: [NSLocalizedDescriptionKey: api.error.message])
+            }
+            throw URLError(.badServerResponse)
+        }
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+}

--- a/site/account/index.html
+++ b/site/account/index.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Haynoi — You're Pro</title>
+  <meta name="description" content="Payment confirmed. Head back to the Haynoi app." />
+  <meta name="theme-color" content="#F7F4EE" />
+  <link rel="icon" href="../icon.png" type="image/png" />
+  <link rel="stylesheet" href="../style.css" />
+  <style>
+    .pro-hero { padding: 10rem 0 6rem; text-align: center; }
+    .pro-hero h1 { font-size: clamp(2rem, 5vw, 3.2rem); }
+    .pro-hero .sub { margin-top: 1rem; color: var(--ink-3, #6B6456);
+      max-width: 480px; margin-left: auto; margin-right: auto; line-height: 1.6; }
+    .pro-badge { display: inline-flex; align-items: center; gap: 6px;
+      border: 1px solid rgba(17,156,154,.35); background: rgba(56,232,208,.08);
+      color: #119C9A; border-radius: 999px; padding: 4px 14px;
+      font-size: 0.8rem; font-weight: 600; letter-spacing: 0.05em;
+      margin-bottom: 1.4rem; }
+    .pro-badge i { width: 6px; height: 6px; border-radius: 50%;
+      background: #119C9A; display: block; }
+    .back-note { margin-top: 2.5rem; color: var(--ink-3, #6B6456); font-size: 0.9rem; }
+  </style>
+
+  <!-- PostHog analytics -->
+  <script src="/analytics.js"></script>
+</head>
+<body>
+<nav>
+  <div class="nav-inner">
+    <a class="nav-logo" href="../">
+      <img src="../icon.png" alt="Haynoi icon" />
+      Haynoi
+    </a>
+  </div>
+</nav>
+
+<main>
+  <section class="pro-hero">
+    <div class="container">
+      <span class="pro-badge"><i></i>PRO</span>
+      <h1 class="serif">Payment confirmed.<br />Welcome to <em>unlimited</em>.</h1>
+      <p class="sub">
+        Your Haynoi Pro subscription is active. Head back to the app —
+        it picks up the upgrade within a few seconds, no restart needed.
+      </p>
+      <p class="back-note">
+        Manage your plan anytime in the app: Settings → Plans &amp; Billing.
+      </p>
+    </div>
+  </section>
+</main>
+</body>
+</html>

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -54,6 +54,18 @@
   <div class="log-wrap">
     <article class="release">
       <div class="release-head">
+        <span class="release-version">0.3.7</span>
+        <span class="release-date">July 5, 2026</span>
+      </div>
+      <p class="release-tagline">Pro is live.</p>
+      <ul>
+        <li>Haynoi Pro: unlimited dictation, all 4 modes, priority transcription — $14.99/month or $125.88/year. Upgrade in Settings → Plans &amp; Billing; checkout runs through Stripe in your browser and the app unlocks within seconds.</li>
+        <li>Fixed usage analytics silently not reporting (counts and timings only — never your words).</li>
+      </ul>
+    </article>
+
+    <article class="release">
+      <div class="release-head">
         <span class="release-version">0.3.6</span>
         <span class="release-date">July 4, 2026</span>
       </div>

--- a/site/index.html
+++ b/site/index.html
@@ -422,9 +422,9 @@
       <div class="pricing-divider" aria-hidden="true"></div>
 
       <div class="pricing-item">
-        <div class="pricing-label">Pro</div>
-        <div class="pricing-value">Coming soon</div>
-        <div class="pricing-sub">Free is all you need today</div>
+        <div class="pricing-label">Pro — unlimited</div>
+        <div class="pricing-value">$14.99/mo</div>
+        <div class="pricing-sub">Or $125.88/yr — save 30%</div>
       </div>
 
       <div class="pricing-divider" aria-hidden="true"></div>

--- a/site/pricing/index.html
+++ b/site/pricing/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <!-- Stripe Checkout cancel_url lands here — send people back home. -->
+  <meta http-equiv="refresh" content="0; url=/" />
+  <title>Haynoi</title>
+  <link rel="icon" href="../icon.png" type="image/png" />
+</head>
+<body></body>
+</html>

--- a/version.env
+++ b/version.env
@@ -8,5 +8,5 @@
 #   - MARKETING_VERSION: semver-ish (MAJOR.MINOR.PATCH), user-visible
 #   - BUILD_NUMBER: monotonic integer, must increase every release
 
-MARKETING_VERSION=0.3.6
-BUILD_NUMBER=28
+MARKETING_VERSION=0.3.7
+BUILD_NUMBER=29


### PR DESCRIPTION
- BillingManager + Plans & Billing UI: real prices ($14.99/mo, $125.88/yr), working Upgrade → Stripe Checkout in browser → webhook-polled Pro unlock, Customer Portal for manage/cancel
- site: /account success page, /pricing cancel redirect, homepage shows real Pro pricing, changelog 0.3.7
- 0.3.7 also carries the PostHog ingestion key fix (0.3.6 shipped a dead key)
- Verified live end-to-end on production: subscription create → webhook → D1 tier flip → unlimited quota, and cancel → back to free (required D1 migration 0003 on haynoi-server, deployed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)