### PR TITLE
chore(version): sync project.yml to 0.3.7/29

### DIFF
--- a/project.yml
+++ b/project.yml
@@ -33,8 +33,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sonpiaz.haynoi
         PRODUCT_NAME: Haynoi
-        MARKETING_VERSION: "0.3.6"
-        CURRENT_PROJECT_VERSION: "28"
+        MARKETING_VERSION: "0.3.7"
+        CURRENT_PROJECT_VERSION: "29"
         INFOPLIST_FILE: Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Resources/Haynoi.entitlements
         SWIFT_VERSION: "5.9"


### PR DESCRIPTION
## What
Bump `project.yml` `MARKETING_VERSION` 0.3.6 → **0.3.7** and `CURRENT_PROJECT_VERSION` 28 → **29**.

## Why
`version.env` (release source of truth) is already `0.3.7/29`, but `project.yml` still read `0.3.6/28`. Local `xcodebuild` reads `project.yml`, so dev/demo builds carried a stale **0.3.6** label — one patch behind the shipped release — and Sparkle saw them as behind the 0.3.7 appcast (triggering a spurious "update"). This aligns the local build label with the released tag.

No code or feature changes — metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)