### PR TITLE
feat(audio): pause media, duck live audio while dictating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Other audio gets out of the way while you dictate.** Music and video pause
+  and resume on their own. A live call, stream or screen recording is dipped in
+  volume instead — never paused, because there is nothing to resume. Haynoi
+  decides from what your Mac is actually playing, so an open-but-idle Zoom no
+  longer keeps your music playing over you, and nothing happens at all when
+  nothing is playing. The level for live audio is adjustable in Settings.
+- If a player ignores the pause (a web player, a game, or Automation access
+  that was declined), Haynoi turns it down instead — so your voice is never
+  competing with your speakers.
+
+### Fixed
+- "Pause audio while dictating" never ran on a fresh install: the switch showed
+  as on while the app read it as off. It works now, and is on by default.
+- The output volume can no longer be left low if Haynoi quits or crashes
+  mid-dictation — the next launch puts it back.
+
 ## [0.3.7] - 2026-07-05
 
 ### Added

--- a/Sources/Haynoi/App/PipelineController.swift
+++ b/Sources/Haynoi/App/PipelineController.swift
@@ -83,6 +83,10 @@ final class PipelineController {
             Task { @MainActor in self?.handleRecorderAbort(reason) }
         }
 
+        // If a previous session died mid-dictation with the output volume
+        // ducked, put it back before the user notices a quiet Mac.
+        MediaController.repairAfterCrash()
+
         // Sync initial state from store
         state.hasFailedDictation = FailedDictationStore.hasAny
         // Accessibility gates both text insertion and the NSEvent hotkey

--- a/Sources/Haynoi/Audio/AudioDucker.swift
+++ b/Sources/Haynoi/Audio/AudioDucker.swift
@@ -1,0 +1,142 @@
+import AppKit
+import Foundation
+
+/// Turns the system output down while you dictate, and — the hard part — always
+/// puts it back.
+///
+/// Ducking is the answer for audio that must not be paused: a Zoom call, a live
+/// stream, a screen recording. Pausing those is destructive; lowering them for
+/// three seconds is not.
+///
+/// The failure mode this class exists to avoid is a user left at volume 0 with
+/// no idea why. Every path is defended:
+///
+///  * **Verified writes** — the HAL is asked what the volume actually is after
+///    every write. USB DACs that ack-but-ignore are detected, and we then
+///    remember that we never really ducked, so restore is not attempted.
+///  * **Crash breadcrumb** — the original volume is written to UserDefaults
+///    *before* the device is touched. If Haynoi dies mid-dictation, the next
+///    launch restores it (`restoreStaleDuck`).
+///  * **User wins** — if the volume changed from what we set (the user reached
+///    for their keyboard mid-dictation), we drop our claim instead of
+///    overwriting their choice.
+///  * **Device-pinned** — restore targets the device UID we ducked, not
+///    whatever happens to be default when dictation ends.
+///
+/// Not tied to a queue: an internal lock makes it safe from anywhere.
+enum AudioDucker {
+
+    /// Volume floor below which ducking buys nothing and only risks a stuck
+    /// restore. 5% is already barely audible.
+    private static let minimumVolumeToDuck: Float = 0.05
+
+    /// How far the volume may drift from what we set before we conclude the
+    /// user (or another app) moved it and back off.
+    private static let ownershipTolerance: Float = 0.05
+
+    private static let breadcrumbKey = "audioDuck.pending"
+
+    private struct Claim {
+        let uid: String
+        let original: Float
+        let applied: Float
+    }
+
+    private static let lock = NSLock()
+    private static var claim: Claim?
+
+    /// Fraction of the original volume to leave audible, 0…1.
+    /// Default 0.2 — quiet enough to stop competing with your voice, loud enough
+    /// that you still notice someone saying your name on the call.
+    static var duckFraction: Float {
+        let stored = UserDefaults.standard.object(forKey: "duckFraction") as? Double
+        return Float(min(max(stored ?? 0.2, 0), 0.9))
+    }
+
+    static var isDucked: Bool {
+        lock.lock(); defer { lock.unlock() }
+        return claim != nil
+    }
+
+    // MARK: - Duck
+
+    @discardableResult
+    static func duck() -> Bool {
+        lock.lock(); defer { lock.unlock() }
+        guard claim == nil else { return true } // already ducked — idempotent
+
+        guard let device = SystemAudio.defaultOutputDevice,
+              let uid = SystemAudio.uid(of: device),
+              let original = SystemAudio.outputVolume(of: device),
+              original >= minimumVolumeToDuck
+        else { return false }
+
+        let target = original * duckFraction
+
+        // Breadcrumb first: if we die between here and the restore, the next
+        // launch still knows what the volume used to be.
+        UserDefaults.standard.set(
+            ["uid": uid, "original": Double(original), "applied": Double(target), "at": Date().timeIntervalSince1970],
+            forKey: breadcrumbKey
+        )
+
+        guard SystemAudio.setOutputVolume(target, on: device) else {
+            // Device lied about the write. Claim nothing, so we never "restore"
+            // a volume we did not change.
+            UserDefaults.standard.removeObject(forKey: breadcrumbKey)
+            NSLog("[Haynoi] Duck rejected by output device — leaving volume alone")
+            return false
+        }
+
+        claim = Claim(uid: uid, original: original, applied: target)
+        return true
+    }
+
+    // MARK: - Restore
+
+    static func restore() {
+        lock.lock(); defer { lock.unlock() }
+        guard let claim else { return }
+        self.claim = nil
+        UserDefaults.standard.removeObject(forKey: breadcrumbKey)
+        apply(claim)
+    }
+
+    /// Called once at launch: repairs a volume left low by a crash, a force
+    /// quit, or a logout in the middle of a dictation.
+    static func restoreStaleDuck() {
+        lock.lock(); defer { lock.unlock() }
+        guard claim == nil,
+              let stored = UserDefaults.standard.dictionary(forKey: breadcrumbKey),
+              let uid = stored["uid"] as? String,
+              let original = stored["original"] as? Double,
+              let applied = stored["applied"] as? Double
+        else { return }
+
+        UserDefaults.standard.removeObject(forKey: breadcrumbKey)
+
+        // A breadcrumb older than a day is not worth acting on: whatever the
+        // volume is now, it is what the user has been living with.
+        if let at = stored["at"] as? TimeInterval, Date().timeIntervalSince1970 - at > 86_400 { return }
+
+        NSLog("[Haynoi] Restoring output volume left ducked by a previous session")
+        apply(Claim(uid: uid, original: Float(original), applied: Float(applied)))
+    }
+
+    /// Restores `claim.original` on the exact device that was ducked, unless the
+    /// volume has since moved away from what we set — in which case the user
+    /// owns it now and we keep our hands off.
+    private static func apply(_ claim: Claim) {
+        guard let device = SystemAudio.device(withUID: claim.uid) else { return }
+        if let current = SystemAudio.outputVolume(of: device),
+           abs(current - claim.applied) > ownershipTolerance {
+            NSLog("[Haynoi] Output volume changed during dictation — keeping the user's level")
+            return
+        }
+        if !SystemAudio.setOutputVolume(claim.original, on: device) {
+            // Retry once: transient HAL failures around a device switch are real,
+            // and a silent Mac is the worst outcome this feature can produce.
+            _ = SystemAudio.setOutputVolume(claim.original, on: device)
+        }
+    }
+}

--- a/Sources/Haynoi/Audio/SystemAudio.swift
+++ b/Sources/Haynoi/Audio/SystemAudio.swift
@@ -1,0 +1,189 @@
+import CoreAudio
+import Foundation
+
+/// Read-mostly wrapper over the CoreAudio HAL — "what is the Mac's audio doing
+/// right now, and can I turn it down?".
+///
+/// Everything here is a synchronous HAL round-trip to `coreaudiod` (~1ms each).
+/// Cheap, but never call it from the main thread on the dictation hot path;
+/// `MediaController` funnels all of it onto a serial background queue.
+///
+/// The per-process properties (`kAudioHardwarePropertyProcessObjectList` and
+/// friends) landed in macOS 14.2. They are plain four-char selectors with no
+/// availability annotation, so on 14.0/14.1 the calls simply return an error
+/// and `processes()` yields an empty list — callers must treat "empty" as
+/// "unknown", not as "silence".
+enum SystemAudio {
+
+    // MARK: - Address helper
+
+    private static func address(
+        _ selector: AudioObjectPropertySelector,
+        _ scope: AudioObjectPropertyScope = kAudioObjectPropertyScopeGlobal,
+        _ element: AudioObjectPropertyElement = kAudioObjectPropertyElementMain
+    ) -> AudioObjectPropertyAddress {
+        AudioObjectPropertyAddress(mSelector: selector, mScope: scope, mElement: element)
+    }
+
+    private static func uint32(_ object: AudioObjectID, _ addr: AudioObjectPropertyAddress) -> UInt32? {
+        var addr = addr
+        var value: UInt32 = 0
+        var size = UInt32(MemoryLayout<UInt32>.size)
+        guard AudioObjectGetPropertyData(object, &addr, 0, nil, &size, &value) == noErr else { return nil }
+        return value
+    }
+
+    private static func string(_ object: AudioObjectID, _ addr: AudioObjectPropertyAddress) -> String? {
+        var addr = addr
+        var out: Unmanaged<CFString>?
+        var size = UInt32(MemoryLayout<CFString?>.size)
+        let status = withUnsafeMutablePointer(to: &out) {
+            AudioObjectGetPropertyData(object, &addr, 0, nil, &size, $0)
+        }
+        guard status == noErr, let out else { return nil }
+        return out.takeRetainedValue() as String
+    }
+
+    // MARK: - Default output device
+
+    static var defaultOutputDevice: AudioObjectID? {
+        var addr = address(kAudioHardwarePropertyDefaultOutputDevice)
+        var device = AudioObjectID(kAudioObjectUnknown)
+        var size = UInt32(MemoryLayout<AudioObjectID>.size)
+        let status = AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &device
+        )
+        guard status == noErr, device != AudioObjectID(kAudioObjectUnknown) else { return nil }
+        return device
+    }
+
+    /// Stable identifier for a device across disconnect/reconnect — used to make
+    /// sure a volume restore lands on the device we actually turned down, and
+    /// not on whatever became "default" after AirPods dropped mid-dictation.
+    static func uid(of device: AudioObjectID) -> String? {
+        string(device, address(kAudioDevicePropertyDeviceUID))
+    }
+
+    static func device(withUID uid: String) -> AudioObjectID? {
+        var addr = address(kAudioHardwarePropertyDevices)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size
+        ) == noErr, size > 0 else { return nil }
+
+        var devices = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &devices
+        ) == noErr else { return nil }
+
+        return devices.first { self.uid(of: $0) == uid }
+    }
+
+    // MARK: - Output volume
+
+    /// Elements that actually carry a settable scalar volume on this device.
+    ///
+    /// Most devices expose a main (element 0) control. Plenty of USB DACs and
+    /// HDMI outputs do not, and only expose per-channel controls — those are the
+    /// devices where naive implementations get stuck muted, so handle both.
+    private static func volumeElements(of device: AudioObjectID) -> [AudioObjectPropertyElement] {
+        func settable(_ element: AudioObjectPropertyElement) -> Bool {
+            var addr = address(kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, element)
+            guard AudioObjectHasProperty(device, &addr) else { return false }
+            var isSettable: DarwinBoolean = false
+            guard AudioObjectIsPropertySettable(device, &addr, &isSettable) == noErr else { return false }
+            return isSettable.boolValue
+        }
+        if settable(kAudioObjectPropertyElementMain) { return [kAudioObjectPropertyElementMain] }
+        return [1, 2].filter(settable)
+    }
+
+    /// Current output volume, 0…1. `nil` when the device has no volume control
+    /// we can drive (HDMI, some pro interfaces) — the caller must then leave the
+    /// device alone rather than guess.
+    static func outputVolume(of device: AudioObjectID) -> Float? {
+        for element in volumeElements(of: device) {
+            var addr = address(kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, element)
+            var value: Float32 = 0
+            var size = UInt32(MemoryLayout<Float32>.size)
+            if AudioObjectGetPropertyData(device, &addr, 0, nil, &size, &value) == noErr {
+                return value
+            }
+        }
+        return nil
+    }
+
+    /// Writes the volume, then reads it back and reports whether it stuck.
+    ///
+    /// The read-back is the point: some USB DAC drivers acknowledge a write they
+    /// never applied. Trusting the OSStatus alone is how you end up believing you
+    /// turned the volume down — and, worse, believing you can put it back.
+    @discardableResult
+    static func setOutputVolume(_ value: Float, on device: AudioObjectID) -> Bool {
+        let clamped = min(max(value, 0), 1)
+        let elements = volumeElements(of: device)
+        guard !elements.isEmpty else { return false }
+
+        for element in elements {
+            var addr = address(kAudioDevicePropertyVolumeScalar, kAudioObjectPropertyScopeOutput, element)
+            var v = Float32(clamped)
+            AudioObjectSetPropertyData(device, &addr, 0, nil, UInt32(MemoryLayout<Float32>.size), &v)
+        }
+
+        guard let readback = outputVolume(of: device) else { return false }
+        return abs(readback - clamped) < 0.02
+    }
+
+    // MARK: - Who is making noise
+
+    /// One audio client of the HAL. `identity` collapses helper processes onto
+    /// their host app (`com.google.Chrome.helper` → `com.google.Chrome`) so a
+    /// browser that plays through one helper and records through another is
+    /// still recognised as a single participant.
+    struct AudioProcess {
+        let pid: pid_t
+        let bundleID: String?
+        let isPlaying: Bool
+        let isCapturing: Bool
+
+        var identity: String {
+            guard let bundleID, !bundleID.isEmpty else { return "pid:\(pid)" }
+            // Strip the ".helper"/".helper.Renderer"… tail Chromium apps append.
+            if let range = bundleID.range(of: ".helper", options: [.caseInsensitive]) {
+                return String(bundleID[bundleID.startIndex..<range.lowerBound])
+            }
+            return bundleID
+        }
+    }
+
+    /// Every process CoreAudio knows about, with its live input/output state.
+    /// Empty on macOS < 14.2 (property unsupported) — treat as "unknown".
+    static func processes() -> [AudioProcess] {
+        var addr = address(kAudioHardwarePropertyProcessObjectList)
+        var size: UInt32 = 0
+        guard AudioObjectGetPropertyDataSize(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size
+        ) == noErr, size > 0 else { return [] }
+
+        var objects = [AudioObjectID](repeating: 0, count: Int(size) / MemoryLayout<AudioObjectID>.size)
+        guard AudioObjectGetPropertyData(
+            AudioObjectID(kAudioObjectSystemObject), &addr, 0, nil, &size, &objects
+        ) == noErr else { return [] }
+
+        return objects.map { object in
+            AudioProcess(
+                pid: uint32(object, address(kAudioProcessPropertyPID)).map { pid_t(bitPattern: $0) } ?? -1,
+                bundleID: string(object, address(kAudioProcessPropertyBundleID)),
+                isPlaying: uint32(object, address(kAudioProcessPropertyIsRunningOutput)) == 1,
+                isCapturing: uint32(object, address(kAudioProcessPropertyIsRunningInput)) == 1
+            )
+        }
+    }
+
+    /// Fallback for macOS < 14.2: is *anything at all* driving the output device?
+    /// Coarse — it cannot exclude Haynoi's own start tone — so it is only used
+    /// when the per-process list is unavailable.
+    static func isOutputActive(on device: AudioObjectID) -> Bool {
+        uint32(device, address(kAudioDevicePropertyDeviceIsRunningSomewhere)) == 1
+    }
+}

--- a/Sources/Haynoi/Settings/SettingsView.swift
+++ b/Sources/Haynoi/Settings/SettingsView.swift
@@ -181,6 +181,8 @@ private struct GeneralTab: View {
     @AppStorage("soundTheme") private var soundTheme = "chime"
     @AppStorage("successDinkEnabled") private var successDinkEnabled = true
     @AppStorage("muteMusic") private var muteMusic = true
+    /// Fraction of the original volume left audible while dictating over a call.
+    @AppStorage("duckFraction") private var duckFraction = 0.2
     @AppStorage("signalAEnabled") private var signalAEnabled = true
     @AppStorage("launchAtLogin") private var launchAtLogin = false
     @AppStorage("shareUsageData") private var shareUsageData = true
@@ -340,13 +342,34 @@ private struct GeneralTab: View {
                 }
 
                 SettingsRow {
-                    Toggle(isOn: $muteMusic) {
-                        Text("Pause audio while dictating")
-                            .font(.system(size: 13))
-                            .foregroundStyle(Color.obsidianLabel(for: scheme))
+                    VStack(alignment: .leading, spacing: 10) {
+                        Toggle(isOn: $muteMusic) {
+                            VStack(alignment: .leading, spacing: 2) {
+                                Text("Quiet other audio while dictating")
+                                    .font(.system(size: 13))
+                                    .foregroundStyle(Color.obsidianLabel(for: scheme))
+                                Text("Music and video pause, then resume. Calls and live audio only dip in volume — never paused.")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                            }
+                        }
+                        .toggleStyle(.switch)
+                        .tint(Color.obsidianAccent(for: scheme))
+
+                        if muteMusic {
+                            HStack(spacing: C.s2) {
+                                Text("Live audio level")
+                                    .font(.system(size: 11))
+                                    .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                                Slider(value: $duckFraction, in: 0...0.6, step: 0.05)
+                                    .tint(Color.obsidianAccent(for: scheme))
+                                Text("\(Int((duckFraction * 100).rounded()))%")
+                                    .font(.system(size: 11).monospacedDigit())
+                                    .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                                    .frame(width: 32, alignment: .trailing)
+                            }
+                        }
                     }
-                    .toggleStyle(.switch)
-                    .tint(Color.obsidianAccent(for: scheme))
                 }
 
                 // v1.3 — Signal A kill-switch (default on, AX-cooperative apps only).

--- a/Sources/Haynoi/System/MediaController.swift
+++ b/Sources/Haynoi/System/MediaController.swift
@@ -1,64 +1,269 @@
 import AppKit
 
-/// Pause/resume media playback during dictation.
+/// Decides what happens to everything else the Mac is playing while you dictate.
 ///
-/// Two tiers:
-///  1. Scriptable players (Spotify, Apple Music) → AppleScript pause/play.
-///     Clean: resumes from the exact position, no toggle ambiguity.
-///  2. Everything else (YouTube/browser video, Podcasts, VLC, games…) →
-///     the system Play/Pause media key, sent only when neither scriptable
-///     player is running (so we never accidentally start a paused Spotify).
+/// The rule Haynoi commits to: **your voice never competes with your speakers,
+/// and nothing you cannot resume gets stopped.**
+///
+/// Two kinds of audio, two different answers:
+///
+///  * **Media** — Spotify, Apple Music, a YouTube tab, a podcast. It has a
+///    position you can return to, so it gets **paused** and resumed on release.
+///  * **Live audio** — a Zoom/Meet/Teams call, a stream, a FaceTime. There is
+///    nothing to resume; pausing is destructive. It gets **ducked** to a
+///    fraction of its volume and restored on release.
+///
+/// The interesting problem is telling the two apart, and the answer is not an
+/// app list. Zoom sitting open all day is not a meeting; Chrome is a video
+/// player and a conference room depending on the tab. So Haynoi asks CoreAudio
+/// what each process is *doing* right now and applies the conversation test:
+///
+///     a process that is playing audio AND capturing the mic
+///     at the same time is in a conversation — duck it, never pause it.
+///
+/// That single test covers Zoom, Google Meet in a browser, Teams, Discord,
+/// Slack huddles and FaceTime without naming any of them, and it stops
+/// pausing music just because a call app happens to be running.
+///
+/// Everything is decided from evidence: if nothing is actually playing, Haynoi
+/// does nothing at all — no blind media keys, no volume writes.
 enum MediaController {
-    private static var pausedApp: String?
+
+    /// AppleScript-controllable players. Preferred over the media key because
+    /// pause/play is explicit: no toggle ambiguity, exact resume position.
+    private static let scriptablePlayers: [String: String] = [
+        "com.spotify.client": "Spotify",
+        "com.apple.Music": "Music",
+    ]
+
+    /// System audio clients that are always "playing" something (Siri's
+    /// listener, UI sounds, accessibility). Counting them as media would mean
+    /// Haynoi thinks audio is playing every single time.
+    private static let systemNoise: Set<String> = [
+        "com.apple.CoreSpeech",
+        "com.apple.assistantd",
+        "com.apple.Siri",
+        "com.apple.siriactionsd",
+        "com.apple.controlcenter",
+        "com.apple.audiomxd",
+        "com.apple.mediaremoted",
+        "com.apple.universalaccessd",
+        "com.apple.accessibility.heard",
+        "systemsoundserverd",
+    ]
+
+    /// Delay before the volume is lowered, so Haynoi's own start tone plays at
+    /// the level the user set. Also keeps every HAL write off the moment the
+    /// mic goes live — nothing here may add latency to recording.
+    private static let duckDelay: TimeInterval = 0.18
+
+    /// How long to wait before checking whether a pause actually worked.
+    /// Media keys get swallowed, and Automation permission for Spotify can be
+    /// denied; either way the audio is still playing and ducking is the answer.
+    private static let pauseVerifyDelay: TimeInterval = 0.45
+
+    private static let queue = DispatchQueue(label: "com.sonpiaz.haynoi.media-controller")
+
+    /// Guarded by `queue`.
+    private static var pausedApps: [String] = []
     private static var didSendMediaKey = false
+    /// Bumped on every start/stop so a delayed verification from a previous
+    /// dictation can never duck audio after we have already restored it.
+    private static var session: UInt64 = 0
 
-    static func pauseIfPlaying() {
-        guard UserDefaults.standard.bool(forKey: "muteMusic") else { return }
+    /// The toggle was never registered, so `bool(forKey:)` read false on a fresh
+    /// install while Settings showed the switch on. Registering here keeps the
+    /// default with the feature that owns it.
+    private static let registerDefaults: Void = {
+        UserDefaults.standard.register(defaults: ["muteMusic": true, "duckFraction": 0.2])
+    }()
 
-        // Tier 1 — Spotify.
-        if isAppRunning("com.spotify.client") {
-            if isPlaying("Spotify") {
-                runAppleScript("tell application \"Spotify\" to pause")
-                pausedApp = "Spotify"
-            }
-            return // Spotify present → don't risk the media key toggling it
-        }
-
-        // Tier 1 — Apple Music.
-        if isAppRunning("com.apple.Music") {
-            if isPlaying("Music") {
-                runAppleScript("tell application \"Music\" to pause")
-                pausedApp = "Music"
-            }
-            return
-        }
-
-        // Live context (call / screen-share / stream / recording): do NOT touch
-        // audio — pausing a shared video or interfering with live sound is worse
-        // than letting it play. Leave everything alone.
-        if isLiveContext() { return }
-
-        // Tier 2 — neither scriptable player running → safe to use the media
-        // key for whatever is playing (browser video, podcast, etc.).
-        sendPlayPauseKey()
-        didSendMediaKey = true
+    private static var isEnabled: Bool {
+        _ = registerDefaults
+        return UserDefaults.standard.bool(forKey: "muteMusic")
     }
 
-    /// True when a conferencing / streaming / screen-recording app is running —
-    /// contexts where auto-pausing media would interrupt something live.
-    /// Delegates to the shared `LiveContext` helper (extracted in v1.1 so the
-    /// "fix that" learn toast can reuse the same set). Behavior-preserving.
-    private static func isLiveContext() -> Bool { LiveContext.isActive() }
+    // MARK: - Entry points
+
+    /// Call once at launch — repairs a volume left low by a crash mid-dictation.
+    static func repairAfterCrash() {
+        _ = registerDefaults
+        queue.async { AudioDucker.restoreStaleDuck() }
+    }
+
+    static func pauseIfPlaying() {
+        guard isEnabled else { return }
+        queue.async {
+            session &+= 1
+            let token = session
+            let scene = Scene.capture()
+            guard scene.hasPlayback else { return }
+
+            // Live conversation in the mix — lower it, never stop it.
+            if scene.hasLiveAudio {
+                queue.asyncAfter(deadline: .now() + duckDelay) {
+                    guard token == session else { return }
+                    AudioDucker.duck()
+                }
+            }
+
+            // Resumable media — stop it properly.
+            for appName in scene.appsToPause {
+                run("tell application \"\(appName)\" to pause")
+                pausedApps.append(appName)
+            }
+            if scene.useMediaKey {
+                sendPlayPauseKey()
+                didSendMediaKey = true
+            } else if scene.duckRemainingMedia {
+                // Something is playing that we cannot address safely: a media
+                // key here could start a paused Spotify instead of stopping the
+                // browser. Ducking is unambiguous.
+                queue.asyncAfter(deadline: .now() + duckDelay) {
+                    guard token == session else { return }
+                    AudioDucker.duck()
+                }
+            }
+
+            // Did the pause actually take? Automation can be denied and media
+            // keys can be ignored. Check, and fall back to ducking.
+            guard !scene.pauseTargets.isEmpty else { return }
+            queue.asyncAfter(deadline: .now() + pauseVerifyDelay) {
+                guard token == session else { return }
+                if Scene.stillPlaying(scene.pauseTargets) {
+                    NSLog("[Haynoi] Media did not pause — ducking instead")
+                    AudioDucker.duck()
+                }
+            }
+        }
+    }
 
     static func resumeIfPaused() {
-        if let app = pausedApp {
-            pausedApp = nil
-            runAppleScript("tell application \"\(app)\" to play")
-            return
+        queue.async {
+            session &+= 1
+
+            // Volume first, so resumed audio comes back at the right level
+            // rather than fading up a beat later.
+            AudioDucker.restore()
+
+            let apps = pausedApps
+            pausedApps = []
+            for app in apps { run("tell application \"\(app)\" to play") }
+
+            if didSendMediaKey {
+                didSendMediaKey = false
+                sendPlayPauseKey() // symmetric toggle back to playing
+            }
         }
-        if didSendMediaKey {
-            didSendMediaKey = false
-            sendPlayPauseKey() // symmetric toggle back to playing
+    }
+
+    // MARK: - Scene
+
+    /// A snapshot of what the Mac is playing, and the plan that follows from it.
+    /// Internal (not private) so the policy can be unit-tested without a mic,
+    /// a call, or a sound card — see `MediaPolicyTests`.
+    struct Scene {
+        /// AppleScript names of players we can pause precisely.
+        let appsToPause: [String]
+        /// Identities to re-check after the pause attempt.
+        let pauseTargets: Set<String>
+        let hasLiveAudio: Bool
+        let useMediaKey: Bool
+        let duckRemainingMedia: Bool
+
+        var hasPlayback: Bool {
+            hasLiveAudio || !appsToPause.isEmpty || useMediaKey || duckRemainingMedia
+        }
+
+        static func capture() -> Scene {
+            let processes = SystemAudio.processes()
+
+            // macOS < 14.2: no per-process data. Fall back to the coarse
+            // "is the output device running" signal plus the running-app
+            // heuristic — the pre-14.2 behaviour, minus the blind media key
+            // when nothing is playing.
+            guard !processes.isEmpty else { return legacyCapture() }
+
+            return plan(
+                processes: processes,
+                myPID: getpid(),
+                myBundleID: Bundle.main.bundleIdentifier,
+                scriptableAppRunning: MediaController.scriptablePlayers.keys.contains(where: isAppRunning)
+            )
+        }
+
+        /// The policy itself, as a pure function of what the machine is playing.
+        /// No CoreAudio, no AppKit, no clock — so every branch is testable.
+        static func plan(
+            processes: [SystemAudio.AudioProcess],
+            myPID: pid_t,
+            myBundleID: String?,
+            scriptableAppRunning: Bool
+        ) -> Scene {
+            let relevant = processes.filter { process in
+                process.pid != myPID
+                    && process.bundleID != myBundleID
+                    && !systemNoise.contains(process.bundleID ?? "")
+            }
+
+            let conversing = Set(relevant.filter(\.isCapturing).map(\.identity))
+            let playing = relevant.filter(\.isPlaying)
+
+            let live = playing.filter { conversing.contains($0.identity) }
+            let media = playing.filter { !conversing.contains($0.identity) }
+
+            var scriptable: [String: String] = [:] // bundle id → AppleScript name
+            var others: Set<String> = []
+            for process in media {
+                if let bundleID = process.bundleID, let appName = MediaController.scriptablePlayers[bundleID] {
+                    scriptable[bundleID] = appName
+                } else {
+                    others.insert(process.identity)
+                }
+            }
+
+            // The media key targets whatever the system considers "now playing",
+            // which may not be the app we mean. With Spotify or Music merely
+            // *running*, a key press can start the wrong thing — so in that case
+            // the leftovers get ducked instead.
+            let hasOthers = !others.isEmpty
+
+            return Scene(
+                appsToPause: Array(scriptable.values),
+                pauseTargets: Set(scriptable.keys).union(others),
+                hasLiveAudio: !live.isEmpty,
+                useMediaKey: hasOthers && !scriptableAppRunning,
+                duckRemainingMedia: hasOthers && scriptableAppRunning
+            )
+        }
+
+        /// Pre-14.2 path: no per-process truth available.
+        private static func legacyCapture() -> Scene {
+            let outputActive = SystemAudio.defaultOutputDevice.map(SystemAudio.isOutputActive) ?? true
+
+            if isAppRunning("com.spotify.client") {
+                return Scene(appsToPause: ["Spotify"], pauseTargets: [], hasLiveAudio: false,
+                             useMediaKey: false, duckRemainingMedia: false)
+            }
+            if isAppRunning("com.apple.Music") {
+                return Scene(appsToPause: ["Music"], pauseTargets: [], hasLiveAudio: false,
+                             useMediaKey: false, duckRemainingMedia: false)
+            }
+            // A conferencing app being *open* is the only live signal available
+            // here, so it stays conservative: duck rather than pause.
+            if LiveContext.isActive() {
+                return Scene(appsToPause: [], pauseTargets: [], hasLiveAudio: outputActive,
+                             useMediaKey: false, duckRemainingMedia: false)
+            }
+            return Scene(appsToPause: [], pauseTargets: [], hasLiveAudio: false,
+                         useMediaKey: outputActive, duckRemainingMedia: false)
+        }
+
+        /// Are any of these identities still producing output?
+        static func stillPlaying(_ identities: Set<String>) -> Bool {
+            let processes = SystemAudio.processes()
+            guard !processes.isEmpty else { return false }
+            return processes.contains { $0.isPlaying && identities.contains($0.identity) }
         }
     }
 
@@ -68,25 +273,25 @@ enum MediaController {
         NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == bundleID }
     }
 
-    /// Whether a scriptable player reports `player state is playing`.
-    private static func isPlaying(_ app: String) -> Bool {
-        guard let script = NSAppleScript(source: "tell application \"\(app)\" to player state is playing") else { return false }
-        var error: NSDictionary?
-        let result = script.executeAndReturnError(&error)
-        return error == nil && result.booleanValue
-    }
-
-    private static func runAppleScript(_ source: String) {
-        if let script = NSAppleScript(source: source) {
+    /// Fire-and-forget Apple Event, dispatched to the main thread.
+    ///
+    /// NSAppleScript is documented as main-thread-only, and a synchronous
+    /// inter-app event needs a run loop for its reply — so this stays on main.
+    /// Async, though: the audio queue never waits for a busy Spotify, and unlike
+    /// the previous implementation it only fires when CoreAudio has already
+    /// confirmed the player is actually producing sound.
+    private static func run(_ source: String) {
+        DispatchQueue.main.async {
+            guard let script = NSAppleScript(source: source) else { return }
             var error: NSDictionary?
             script.executeAndReturnError(&error)
+            if let error { NSLog("[Haynoi] AppleScript failed: %@", error) }
         }
     }
 
     /// Post the system-defined Play/Pause media key (NX_KEYTYPE_PLAY = 16).
     /// Pauses/resumes whatever currently holds the system "now playing" target
-    /// (browser video, Podcasts, VLC, …) without touching output volume, so
-    /// Haynoi's own start/stop chord stays audible.
+    /// (browser video, Podcasts, VLC, …) without touching output volume.
     private static func sendPlayPauseKey() {
         func post(_ keyDown: Bool) {
             let rawFlags = keyDown ? 0xA00 : 0xB00

--- a/Tests/MediaPolicyTests.swift
+++ b/Tests/MediaPolicyTests.swift
@@ -1,0 +1,134 @@
+import XCTest
+@testable import Haynoi
+
+/// The pause-vs-duck policy, tested as a pure function of what the Mac is
+/// playing. No mic, no call, no sound card — every branch of the decision that
+/// runs when you press the dictation key.
+final class MediaPolicyTests: XCTestCase {
+
+    private func process(
+        _ bundleID: String?,
+        pid: pid_t = 1,
+        playing: Bool = false,
+        capturing: Bool = false
+    ) -> SystemAudio.AudioProcess {
+        SystemAudio.AudioProcess(pid: pid, bundleID: bundleID, isPlaying: playing, isCapturing: capturing)
+    }
+
+    private func plan(
+        _ processes: [SystemAudio.AudioProcess],
+        scriptableAppRunning: Bool = false
+    ) -> MediaController.Scene {
+        MediaController.Scene.plan(
+            processes: processes,
+            myPID: 999,
+            myBundleID: "com.sonpiaz.haynoi",
+            scriptableAppRunning: scriptableAppRunning
+        )
+    }
+
+    // MARK: - Nothing playing
+
+    func testSilenceDoesNothing() {
+        // Apps open but idle: Spotify sitting there, Zoom sitting there.
+        let scene = plan([
+            process("com.spotify.client", pid: 1),
+            process("us.zoom.xos", pid: 2),
+        ], scriptableAppRunning: true)
+
+        XCTAssertFalse(scene.hasPlayback, "No audio playing — Haynoi must not touch anything")
+        XCTAssertFalse(scene.useMediaKey)
+        XCTAssertFalse(scene.hasLiveAudio)
+        XCTAssertTrue(scene.appsToPause.isEmpty)
+    }
+
+    /// The regression that motivated the rewrite: Zoom open all day used to
+    /// suppress pausing entirely, so music kept playing over every dictation.
+    func testIdleZoomDoesNotBlockPausingMusic() {
+        let scene = plan([
+            process("us.zoom.xos", pid: 2),                       // open, silent
+            process("com.spotify.client", pid: 3, playing: true),  // actually playing
+        ], scriptableAppRunning: true)
+
+        XCTAssertEqual(scene.appsToPause, ["Spotify"])
+        XCTAssertFalse(scene.hasLiveAudio, "An open Zoom is not a meeting")
+    }
+
+    // MARK: - The conversation test
+
+    func testPlayingAndCapturingIsDuckedNotPaused() {
+        let scene = plan([process("us.zoom.xos", pid: 2, playing: true, capturing: true)])
+
+        XCTAssertTrue(scene.hasLiveAudio, "A live call must be ducked")
+        XCTAssertTrue(scene.appsToPause.isEmpty, "A live call must never be paused")
+        XCTAssertFalse(scene.useMediaKey)
+    }
+
+    /// Google Meet in a browser: audio out and mic in land on different helper
+    /// processes of the same app, so identity has to collapse them.
+    func testBrowserCallIsRecognisedAcrossHelperProcesses() {
+        let scene = plan([
+            process("com.google.Chrome.helper", pid: 10, playing: true),
+            process("com.google.Chrome.helper.Renderer", pid: 11, capturing: true),
+        ])
+
+        XCTAssertTrue(scene.hasLiveAudio, "Meet in Chrome is a call, not a video")
+        XCTAssertFalse(scene.useMediaKey, "Never send a media key at a live call")
+    }
+
+    /// Same browser, no mic in use — that is a video, and it gets paused.
+    func testBrowserVideoUsesMediaKey() {
+        let scene = plan([process("com.google.Chrome.helper", pid: 10, playing: true)])
+
+        XCTAssertTrue(scene.useMediaKey)
+        XCTAssertFalse(scene.hasLiveAudio)
+        XCTAssertEqual(scene.pauseTargets, ["com.google.Chrome"])
+    }
+
+    // MARK: - Mixed scenes
+
+    func testCallAndMusicTogetherDucksCallAndPausesMusic() {
+        let scene = plan([
+            process("us.zoom.xos", pid: 2, playing: true, capturing: true),
+            process("com.spotify.client", pid: 3, playing: true),
+        ], scriptableAppRunning: true)
+
+        XCTAssertTrue(scene.hasLiveAudio, "Zoom gets ducked")
+        XCTAssertEqual(scene.appsToPause, ["Spotify"], "Spotify gets paused")
+    }
+
+    /// With Spotify running, the media key is ambiguous — it can start the
+    /// paused player instead of stopping the browser. Duck the leftovers.
+    func testMediaKeyIsAvoidedWhenAScriptablePlayerIsRunning() {
+        let scene = plan([
+            process("com.google.Chrome.helper", pid: 10, playing: true),
+        ], scriptableAppRunning: true)
+
+        XCTAssertFalse(scene.useMediaKey, "Media key could resume a paused Spotify")
+        XCTAssertTrue(scene.duckRemainingMedia)
+    }
+
+    // MARK: - Noise filtering
+
+    func testSiriListenerIsNotTreatedAsPlayback() {
+        // CoreSpeech reports output AND input constantly; counting it would make
+        // Haynoi believe a call is in progress on every single dictation.
+        let scene = plan([process("com.apple.CoreSpeech", pid: 5, playing: true, capturing: true)])
+
+        XCTAssertFalse(scene.hasPlayback)
+        XCTAssertFalse(scene.hasLiveAudio)
+    }
+
+    func testHaynoiOwnAudioIsIgnored() {
+        // Our own start tone plays through the same device while we capture the
+        // mic — the textbook false "live call".
+        let scene = plan([
+            process("com.sonpiaz.haynoi", pid: 999, playing: true, capturing: true),
+            process(nil, pid: 42, playing: true), // a CLI player, no bundle id
+        ])
+
+        XCTAssertFalse(scene.hasLiveAudio)
+        XCTAssertEqual(scene.pauseTargets, ["pid:42"], "Bundle-less players are still real playback")
+        XCTAssertTrue(scene.useMediaKey)
+    }
+}


### PR DESCRIPTION
## The gap

When you hold the dictation key, everything else the Mac is playing keeps playing. The old `MediaController` tried to help but was driven by **which apps are open**, not by what is actually playing — three consequences:

1. **A live meeting got nothing.** With Zoom/Meet/Teams open, the controller bailed out entirely. Meeting audio kept blasting into the mic.
2. **An idle Zoom suppressed everything.** Zoom open all day (the normal state) meant music never paused — the bail-out fired whether or not a meeting was in progress.
3. **The setting never ran.** `muteMusic` was never in `register(defaults:)`, so `bool(forKey:)` read **false** on a fresh install while Settings showed the switch **on**. The feature was effectively dead until a user toggled it off and back on.

## What reference products do

| | approach | gap |
|---|---|---|
| **superwhisper** | two independent per-mode toggles: *Mute Audio While Recording* + *Pause Media While Recording* | user has to know which one their situation needs |
| **Wispr Flow** | mutes the default output device, restores on stop; only if audio was already playing | off by default on Mac; all-or-nothing mute |
| **VoiceInk** | *Mute System Audio* on by default via `kAudioDevicePropertyMute` | [#640](https://github.com/Beingpax/VoiceInk/issues/640): DACs ack a mute they never applied → **users stuck at volume 0**; [#683](https://github.com/Beingpax/VoiceInk/issues/683): asks for ducking instead of binary mute |

Nobody decides automatically. Every one of them makes the user pick a global policy in advance.

## What this ships

**One rule: your voice never competes with your speakers, and nothing you cannot resume gets stopped.**

- **Media** — Spotify, Music, a video tab, a podcast → **paused**, resumed on release.
- **Live audio** — a call, a stream, a screen recording → **ducked** to a fraction of volume, restored on release. Never paused; there is nothing to resume.
- **Silence** → nothing happens at all. No blind media keys, no volume writes.

The classification uses no app list. It asks CoreAudio what each process is *doing* (`kAudioProcessPropertyIsRunningOutput` / `IsRunningInput`, macOS 14.2+) and applies the **conversation test**:

> a process playing audio **and** capturing the mic at the same time is in a conversation — duck it, never pause it.

That covers Zoom, Meet-in-a-browser, Teams, Discord, Slack huddles and FaceTime without naming any of them, and it fixes gap #2 for free: an idle Zoom plays nothing, so it is not a meeting. Helper processes collapse onto their host app (`com.google.Chrome.helper` → `com.google.Chrome`), so a browser that plays through one helper and records through another still reads as one participant. Pre-14.2 falls back to the old running-app heuristic.

**Self-healing pause.** Media keys get swallowed and Automation access for Spotify can be declined. 450 ms after any pause attempt Haynoi re-checks; if the audio is still playing, it ducks instead. The promise holds even when the pause does not.

## Not getting anyone stuck at volume 0

VoiceInk #640 is the bug this feature is designed around:

- **Verified writes** — read back after every write; DACs that ack-but-ignore are detected, and we then know we never really ducked, so no bogus restore.
- **Crash breadcrumb** — the original volume goes to UserDefaults *before* the device is touched; the next launch repairs it (`repairAfterCrash()` in `PipelineController.setup()`).
- **User wins** — volume moved during dictation is left alone rather than overwritten.
- **Device-pinned** — restore targets the device UID that was ducked, not whatever is default when AirPods drop mid-sentence.
- Never blocks recording start: all HAL work is on a serial background queue, and the duck lands 180 ms in so the start tone still plays at the user's level.

## Settings

`muteMusic` relabelled **"Quiet other audio while dictating"** (on by default, and now actually registered), plus a **Live audio level** slider (`duckFraction`, default 20%) shown when it is on.

## Verification

- `xcodebuild test` → **26 tests, 0 failures** (9 new). Policy branches covered: idle-Zoom regression, conversation test, browser call across helper PIDs, browser video, call + music together, media-key ambiguity, Siri-listener filtering, self-audio filtering.
- Integration harness compiled against the real sources and run with audio playing on this machine: media key failed → **duck fallback fired** (0.4375 → 0.0875), `resumeIfPaused` restored **exactly** 0.43749997, breadcrumb cleared, and a simulated crash was repaired at next launch.

## Known limit

A browser can hold its output stream open for a few seconds after you pause it yourself, so a media key may briefly restart it. The symmetric key on release puts it back. Strictly better than before, where the key was sent regardless of playback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017wJXYCRfgstzU1EJfLY6rx