### PR TITLE
fix: post-paste scroll freeze + blind media-key toggle

### DIFF
--- a/Sources/Haynoi/Input/TextInserter.swift
+++ b/Sources/Haynoi/Input/TextInserter.swift
@@ -556,6 +556,23 @@ enum TextInserter {
             return false
         }
 
+        // Posting a synthetic event makes macOS filter the user's OWN input for
+        // localEventsSuppressionInterval — measured at 0.250s, with the default
+        // filter permitting *nothing*. Two posts 20ms apart chain into ~270ms
+        // in which the mouse wheel is dead, which reads as "scrolling is
+        // frozen" right after every dictation. Let the user's mouse through.
+        //
+        // Keyboard stays filtered on purpose: the paste posts key-down and
+        // key-up 20ms apart, both carrying .maskCommand, so a real keystroke
+        // landing between them could be read as a ⌘-shortcut.
+        for state in [CGEventSuppressionState.eventSuppressionStateSuppressionInterval,
+                      CGEventSuppressionState.eventSuppressionStateRemoteMouseDrag] {
+            src.setLocalEventsFilterDuringSuppressionState(
+                [.permitLocalMouseEvents, .permitSystemDefinedEvents],
+                state: state
+            )
+        }
+
         guard let down = CGEvent(keyboardEventSource: src, virtualKey: vKeyCode, keyDown: true),
               let up   = CGEvent(keyboardEventSource: src, virtualKey: vKeyCode, keyDown: false) else {
             NSLog("[Haynoi] CGEvent creation failed")

--- a/Sources/Haynoi/System/MediaController.swift
+++ b/Sources/Haynoi/System/MediaController.swift
@@ -7,8 +7,13 @@ import AppKit
 ///
 /// Two kinds of audio, two different answers:
 ///
-///  * **Media** — Spotify, Apple Music, a YouTube tab, a podcast. It has a
-///    position you can return to, so it gets **paused** and resumed on release.
+///  * **Media we can name** — Spotify and Apple Music, driven by AppleScript.
+///    `pause` and `play` are explicit, so these get **paused** and resumed at
+///    the exact position on release.
+///  * **Media we cannot name** — a YouTube tab, a podcast app, VLC. There is
+///    no way to address these except the play/pause media key, and that key is
+///    a *toggle*: get the guess wrong and it starts something instead of
+///    stopping it. So they get **ducked** too.
 ///  * **Live audio** — a Zoom/Meet/Teams call, a stream, a FaceTime. There is
 ///    nothing to resume; pausing is destructive. It gets **ducked** to a
 ///    fraction of its volume and restored on release.
@@ -25,8 +30,12 @@ import AppKit
 /// Slack huddles and FaceTime without naming any of them, and it stops
 /// pausing music just because a call app happens to be running.
 ///
-/// Everything is decided from evidence: if nothing is actually playing, Haynoi
-/// does nothing at all — no blind media keys, no volume writes.
+/// Everything is decided from evidence, and the one action that could not be
+/// taken back — the play/pause media key — is gone. CoreAudio reports whether a
+/// process has an output stream open, not whether it is making a sound, and a
+/// browser sitting on a loaded track reports the former all day. Every remaining
+/// action is safe under that uncertainty: AppleScript `pause` is explicit, and
+/// ducking is inaudible when there was nothing to hear.
 enum MediaController {
 
     /// AppleScript-controllable players. Preferred over the media key because
@@ -66,7 +75,6 @@ enum MediaController {
 
     /// Guarded by `queue`.
     private static var pausedApps: [String] = []
-    private static var didSendMediaKey = false
     /// Bumped on every start/stop so a delayed verification from a previous
     /// dictation can never duck audio after we have already restored it.
     private static var session: UInt64 = 0
@@ -112,13 +120,10 @@ enum MediaController {
                 run("tell application \"\(appName)\" to pause")
                 pausedApps.append(appName)
             }
-            if scene.useMediaKey {
-                sendPlayPauseKey()
-                didSendMediaKey = true
-            } else if scene.duckRemainingMedia {
-                // Something is playing that we cannot address safely: a media
-                // key here could start a paused Spotify instead of stopping the
-                // browser. Ducking is unambiguous.
+            if scene.duckRemainingMedia {
+                // Something we cannot address safely by name. Ducking is
+                // unambiguous; a media key here could start a paused player
+                // instead of stopping the browser.
                 queue.asyncAfter(deadline: .now() + duckDelay) {
                     guard token == session else { return }
                     AudioDucker.duck()
@@ -149,11 +154,6 @@ enum MediaController {
             let apps = pausedApps
             pausedApps = []
             for app in apps { run("tell application \"\(app)\" to play") }
-
-            if didSendMediaKey {
-                didSendMediaKey = false
-                sendPlayPauseKey() // symmetric toggle back to playing
-            }
         }
     }
 
@@ -168,11 +168,10 @@ enum MediaController {
         /// Identities to re-check after the pause attempt.
         let pauseTargets: Set<String>
         let hasLiveAudio: Bool
-        let useMediaKey: Bool
         let duckRemainingMedia: Bool
 
         var hasPlayback: Bool {
-            hasLiveAudio || !appsToPause.isEmpty || useMediaKey || duckRemainingMedia
+            hasLiveAudio || !appsToPause.isEmpty || duckRemainingMedia
         }
 
         static func capture() -> Scene {
@@ -187,8 +186,7 @@ enum MediaController {
             return plan(
                 processes: processes,
                 myPID: getpid(),
-                myBundleID: Bundle.main.bundleIdentifier,
-                scriptableAppRunning: MediaController.scriptablePlayers.keys.contains(where: isAppRunning)
+                myBundleID: Bundle.main.bundleIdentifier
             )
         }
 
@@ -197,8 +195,7 @@ enum MediaController {
         static func plan(
             processes: [SystemAudio.AudioProcess],
             myPID: pid_t,
-            myBundleID: String?,
-            scriptableAppRunning: Bool
+            myBundleID: String?
         ) -> Scene {
             let relevant = processes.filter { process in
                 process.pid != myPID
@@ -222,18 +219,24 @@ enum MediaController {
                 }
             }
 
-            // The media key targets whatever the system considers "now playing",
-            // which may not be the app we mean. With Spotify or Music merely
-            // *running*, a key press can start the wrong thing — so in that case
-            // the leftovers get ducked instead.
-            let hasOthers = !others.isEmpty
-
+            // Anything we cannot name gets ducked, never toggled.
+            //
+            // `isPlaying` is kAudioProcessPropertyIsRunningOutput — "has an
+            // output stream open", which is not the same as "is making a
+            // sound". Measured on a silent Mac: com.apple.WebKit.GPU reports
+            // it continuously, because a browser holding an idle audio context
+            // is enough. The play/pause media key is a *toggle*, so firing it
+            // on that evidence started the last track instead of stopping
+            // anything — and the same key on release then cut it off, after
+            // the volume had already been restored, with an audible thump.
+            //
+            // Ducking cannot make that mistake: it is non-destructive, and if
+            // nothing was audible it is inaudible.
             return Scene(
                 appsToPause: Array(scriptable.values),
                 pauseTargets: Set(scriptable.keys).union(others),
                 hasLiveAudio: !live.isEmpty,
-                useMediaKey: hasOthers && !scriptableAppRunning,
-                duckRemainingMedia: hasOthers && scriptableAppRunning
+                duckRemainingMedia: !others.isEmpty
             )
         }
 
@@ -243,20 +246,23 @@ enum MediaController {
 
             if isAppRunning("com.spotify.client") {
                 return Scene(appsToPause: ["Spotify"], pauseTargets: [], hasLiveAudio: false,
-                             useMediaKey: false, duckRemainingMedia: false)
+                             duckRemainingMedia: false)
             }
             if isAppRunning("com.apple.Music") {
                 return Scene(appsToPause: ["Music"], pauseTargets: [], hasLiveAudio: false,
-                             useMediaKey: false, duckRemainingMedia: false)
+                             duckRemainingMedia: false)
             }
             // A conferencing app being *open* is the only live signal available
             // here, so it stays conservative: duck rather than pause.
             if LiveContext.isActive() {
                 return Scene(appsToPause: [], pauseTargets: [], hasLiveAudio: outputActive,
-                             useMediaKey: false, duckRemainingMedia: false)
+                             duckRemainingMedia: false)
             }
+            // Without per-process truth this path knows only that *something*
+            // is driving the output. That was enough to fire a blind media
+            // key; it is not enough to be sure anything is audible, so duck.
             return Scene(appsToPause: [], pauseTargets: [], hasLiveAudio: false,
-                         useMediaKey: outputActive, duckRemainingMedia: false)
+                         duckRemainingMedia: outputActive)
         }
 
         /// Are any of these identities still producing output?
@@ -289,27 +295,4 @@ enum MediaController {
         }
     }
 
-    /// Post the system-defined Play/Pause media key (NX_KEYTYPE_PLAY = 16).
-    /// Pauses/resumes whatever currently holds the system "now playing" target
-    /// (browser video, Podcasts, VLC, …) without touching output volume.
-    private static func sendPlayPauseKey() {
-        func post(_ keyDown: Bool) {
-            let rawFlags = keyDown ? 0xA00 : 0xB00
-            let data1 = (16 << 16) | ((keyDown ? 0xA : 0xB) << 8)
-            let event = NSEvent.otherEvent(
-                with: .systemDefined,
-                location: .zero,
-                modifierFlags: NSEvent.ModifierFlags(rawValue: UInt(rawFlags)),
-                timestamp: ProcessInfo.processInfo.systemUptime,
-                windowNumber: 0,
-                context: nil,
-                subtype: 8,
-                data1: data1,
-                data2: -1
-            )
-            event?.cgEvent?.post(tap: .cghidEventTap)
-        }
-        post(true)
-        post(false)
-    }
 }

--- a/Tests/MediaPolicyTests.swift
+++ b/Tests/MediaPolicyTests.swift
@@ -1,3 +1,4 @@
+import AppKit
 import XCTest
 @testable import Haynoi
 
@@ -15,15 +16,11 @@ final class MediaPolicyTests: XCTestCase {
         SystemAudio.AudioProcess(pid: pid, bundleID: bundleID, isPlaying: playing, isCapturing: capturing)
     }
 
-    private func plan(
-        _ processes: [SystemAudio.AudioProcess],
-        scriptableAppRunning: Bool = false
-    ) -> MediaController.Scene {
+    private func plan(_ processes: [SystemAudio.AudioProcess]) -> MediaController.Scene {
         MediaController.Scene.plan(
             processes: processes,
             myPID: 999,
-            myBundleID: "com.sonpiaz.haynoi",
-            scriptableAppRunning: scriptableAppRunning
+            myBundleID: "com.sonpiaz.haynoi"
         )
     }
 
@@ -34,10 +31,10 @@ final class MediaPolicyTests: XCTestCase {
         let scene = plan([
             process("com.spotify.client", pid: 1),
             process("us.zoom.xos", pid: 2),
-        ], scriptableAppRunning: true)
+        ])
 
         XCTAssertFalse(scene.hasPlayback, "No audio playing — Haynoi must not touch anything")
-        XCTAssertFalse(scene.useMediaKey)
+        XCTAssertFalse(scene.duckRemainingMedia)
         XCTAssertFalse(scene.hasLiveAudio)
         XCTAssertTrue(scene.appsToPause.isEmpty)
     }
@@ -48,7 +45,7 @@ final class MediaPolicyTests: XCTestCase {
         let scene = plan([
             process("us.zoom.xos", pid: 2),                       // open, silent
             process("com.spotify.client", pid: 3, playing: true),  // actually playing
-        ], scriptableAppRunning: true)
+        ])
 
         XCTAssertEqual(scene.appsToPause, ["Spotify"])
         XCTAssertFalse(scene.hasLiveAudio, "An open Zoom is not a meeting")
@@ -61,7 +58,7 @@ final class MediaPolicyTests: XCTestCase {
 
         XCTAssertTrue(scene.hasLiveAudio, "A live call must be ducked")
         XCTAssertTrue(scene.appsToPause.isEmpty, "A live call must never be paused")
-        XCTAssertFalse(scene.useMediaKey)
+        XCTAssertFalse(scene.duckRemainingMedia)
     }
 
     /// Google Meet in a browser: audio out and mic in land on different helper
@@ -73,14 +70,16 @@ final class MediaPolicyTests: XCTestCase {
         ])
 
         XCTAssertTrue(scene.hasLiveAudio, "Meet in Chrome is a call, not a video")
-        XCTAssertFalse(scene.useMediaKey, "Never send a media key at a live call")
+        XCTAssertFalse(scene.duckRemainingMedia, "A live call is ducked as live audio, not as leftover media")
     }
 
-    /// Same browser, no mic in use — that is a video, and it gets paused.
-    func testBrowserVideoUsesMediaKey() {
+    /// Same browser, no mic in use — that is a video, and it gets ducked.
+    /// It used to get a play/pause media key, but CoreAudio cannot tell an
+    /// open output stream from an audible one, so the toggle was a coin flip.
+    func testBrowserVideoIsDucked() {
         let scene = plan([process("com.google.Chrome.helper", pid: 10, playing: true)])
 
-        XCTAssertTrue(scene.useMediaKey)
+        XCTAssertTrue(scene.duckRemainingMedia)
         XCTAssertFalse(scene.hasLiveAudio)
         XCTAssertEqual(scene.pauseTargets, ["com.google.Chrome"])
     }
@@ -91,7 +90,7 @@ final class MediaPolicyTests: XCTestCase {
         let scene = plan([
             process("us.zoom.xos", pid: 2, playing: true, capturing: true),
             process("com.spotify.client", pid: 3, playing: true),
-        ], scriptableAppRunning: true)
+        ])
 
         XCTAssertTrue(scene.hasLiveAudio, "Zoom gets ducked")
         XCTAssertEqual(scene.appsToPause, ["Spotify"], "Spotify gets paused")
@@ -99,12 +98,12 @@ final class MediaPolicyTests: XCTestCase {
 
     /// With Spotify running, the media key is ambiguous — it can start the
     /// paused player instead of stopping the browser. Duck the leftovers.
-    func testMediaKeyIsAvoidedWhenAScriptablePlayerIsRunning() {
+    func testLeftoverMediaIsDuckedWhenAScriptablePlayerIsRunning() {
         let scene = plan([
             process("com.google.Chrome.helper", pid: 10, playing: true),
-        ], scriptableAppRunning: true)
+        ])
 
-        XCTAssertFalse(scene.useMediaKey, "Media key could resume a paused Spotify")
+        XCTAssertTrue(scene.duckRemainingMedia, "Ducked, because a media key could resume a paused Spotify")
         XCTAssertTrue(scene.duckRemainingMedia)
     }
 
@@ -129,6 +128,67 @@ final class MediaPolicyTests: XCTestCase {
 
         XCTAssertFalse(scene.hasLiveAudio)
         XCTAssertEqual(scene.pauseTargets, ["pid:42"], "Bundle-less players are still real playback")
-        XCTAssertTrue(scene.useMediaKey)
+        XCTAssertTrue(scene.duckRemainingMedia)
+    }
+
+    // MARK: - Regression: a blind media key started music that was never playing
+
+    /// Measured on a silent Mac (macOS 26, 2026-08-20): with nothing audible,
+    /// CoreAudio still reports `com.apple.WebKit.GPU` as running output —
+    /// persistently, sampled every 3s for 18s. `isPlaying` is
+    /// kAudioProcessPropertyIsRunningOutput, i.e. "has an output stream open",
+    /// NOT "is making a sound". A browser holding an idle audio context is
+    /// enough. Treating it as media fired the play/pause key, which is a
+    /// *toggle* — so it started the last track instead of stopping anything.
+    func testIdleBrowserAudioStreamIsNotPlayback() {
+        let scene = plan([
+            process("com.apple.WebKit.GPU", pid: 88034, playing: true),
+            process("com.shure.motivmix", pid: 27475, playing: true, capturing: true),
+        ])
+
+        XCTAssertTrue(
+            scene.appsToPause.isEmpty,
+            "Nothing is named and playing, so nothing may be paused"
+        )
+        // The fix: an idle browser stream can only ever lower the volume for a
+        // moment. It can never start a track, which a toggle did.
+    }
+
+    /// The same silent scene, but with Spotify open and paused — the case the
+    /// user hit: "a song waiting on the computer" that suddenly played.
+    func testIdleBrowserWithPausedSpotifyNeverStartsPlayback() {
+        let scene = plan([
+            process("com.apple.WebKit.GPU", pid: 88034, playing: true),
+            process("com.spotify.client", pid: 3), // open, paused, silent
+        ])
+
+        XCTAssertTrue(scene.appsToPause.isEmpty, "Nothing is playing, so nothing to pause")
+    }
+
+    // MARK: - Live machine
+
+    /// The tests above feed `plan()` a scene typed by hand. This one runs the
+    /// real path — CoreAudio → `processes()` → `capture()` → the policy — on
+    /// whatever this Mac happens to be doing, and asserts the one property that
+    /// must hold no matter what: Haynoi never issues an action that could
+    /// *start* audio. Environment-dependent by design, so it asserts safety,
+    /// not a particular scene.
+    func testLiveSceneNeverStartsPlayback() {
+        let scene = MediaController.Scene.capture()
+        let running = ["com.spotify.client", "com.apple.Music"].filter { id in
+            NSWorkspace.shared.runningApplications.contains { $0.bundleIdentifier == id }
+        }
+        print("[live] appsToPause=\(scene.appsToPause) hasLiveAudio=\(scene.hasLiveAudio) "
+            + "duckRemainingMedia=\(scene.duckRemainingMedia) targets=\(scene.pauseTargets) "
+            + "scriptablePlayersRunning=\(running)")
+
+        for app in scene.appsToPause {
+            XCTAssertTrue(
+                running.contains(app == "Spotify" ? "com.spotify.client" : "com.apple.Music"),
+                "\(app) is not even running — pausing it would be a blind command"
+            )
+        }
+        // Ducking and AppleScript pause are the only two actions left, and
+        // neither can begin playback. A toggle could, and no longer exists.
     }
 }


### PR DESCRIPTION
Two fixes that were sitting as WIP in the working tree, now verified by the full test suite (29/29 pass).

## Post-paste scroll freeze
Posting the synthetic Cmd+V makes macOS suppress the user's own input for ~250ms per event post — two posts chain into ~270ms of dead mouse wheel after every dictation. The suppression filter now permits local mouse and system-defined events; keyboard stays filtered so a real keystroke can't land between the paste's key-down/up carrying ⌘.

## Blind media-key toggle removed
CoreAudio's `isRunningOutput` means "has an output stream open", not "is audible" — an idle browser reports it all day. The play/pause key is a toggle, so firing it on that evidence could *start* playback instead of stopping it (measured: silent Mac, WebKit.GPU reporting output continuously). The key is gone entirely: Spotify/Music keep explicit AppleScript pause/resume; everything unnameable (browser video, VLC, podcasts) is ducked — non-destructive, and inaudible when nothing was audible.

## Tests
- `MediaPolicyTests` rewritten for the new scene plan + a regression suite for the idle-browser false positive.
- Full suite: **29/29 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ
