### PR TITLE
feat(learning): confirmed correction pairs ground the AI rewrite pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Your corrections now teach the AI cleanup pass.** When a mode runs the AI
+  rewrite, Haynoi shows it the exact fixes you've confirmed before ("Hanoi" →
+  "Haynoi"), so it repairs the misrecognitions that vocabulary hints alone
+  can't — like a personal name that sounds identical to a common word. Only
+  fixes you've confirmed are used, and they never leave your dictionary except
+  inside the dictation being cleaned up.
 - **Other audio gets out of the way while you dictate.** Music and video pause
   and resume on their own. A live call, stream or screen recording is dipped in
   volume instead — never paused, because there is nothing to resume. Haynoi

--- a/Sources/Haynoi/System/PersonalDictionary.swift
+++ b/Sources/Haynoi/System/PersonalDictionary.swift
@@ -354,6 +354,25 @@ final class PersonalDictionary {
         return result
     }
 
+    /// Known (wrong → right) pairs for the LLM rewrite pass — grounded few-shot
+    /// context (v2 Phase 1, redesign/10-DICTATION-LEARNING-V2.md). Trust bar is
+    /// the SAME activation gate as the deterministic replace (`firesAsReplacement`)
+    /// — no parallel gate, so an unconfirmed learned rule can't reach the LLM
+    /// either. Frequency-ordered, capped: the dictionary is the retriever.
+    func correctionPairs(max limit: Int = 10) -> [(wrong: String, right: String)] {
+        enabledEntries(kinds: [.replacement])
+            .filter { $0.firesAsReplacement }
+            .sorted { $0.frequency > $1.frequency }
+            .prefix(limit)
+            .compactMap { entry in
+                guard let w = entry.wrong?.trimmingCharacters(in: .whitespacesAndNewlines),
+                      !w.isEmpty else { return nil }
+                let r = entry.right.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !r.isEmpty else { return nil }
+                return (wrong: w, right: r)
+            }
+    }
+
     // MARK: - Deterministic replacement (Feedback path #2, §5.3)
 
     /// Applies enabled `.replacement` entries to `text`. Whole-word/phrase match

--- a/Sources/Haynoi/Transcription/STTProvider.swift
+++ b/Sources/Haynoi/Transcription/STTProvider.swift
@@ -285,6 +285,43 @@ enum STTProvider {
         return message
     }
 
+    /// Builds the rewrite pass's system prompt: the user's glossary as context,
+    /// then known (wrong → right) pairs from their correction history as grounded
+    /// few-shot examples, then the mode's own prompt. The pairs carry the cases
+    /// soft biasing cannot fix — verified against the production models
+    /// 2026-08-29: the STT prompt glossary corrected "Mandec"→"Mandeck" but
+    /// could not beat the common word "Hanoi" for "Haynoi"; the pair could.
+    /// The "only where it occurs / never insert elsewhere" framing is
+    /// load-bearing: an UNgrounded LLM fix-up pass over-corrects, so the pairs
+    /// are licensed as the only corrections. The `wrong` forms go ONLY here —
+    /// never into the STT prompt, where prior-text conditioning would bias the
+    /// decoder TOWARD the error. See redesign/10-DICTATION-LEARNING-V2.md.
+    static func rewriteSystemPrompt(
+        base: String,
+        glossary: [String],
+        pairs: [(wrong: String, right: String)]
+    ) -> String {
+        var sections: [String] = []
+        if !glossary.isEmpty {
+            sections.append(
+                "The user's preferred spellings for names and terms (use these exact forms when they occur): "
+                    + glossary.joined(separator: ", ") + "."
+            )
+        }
+        if !pairs.isEmpty {
+            let lines = pairs
+                .map { "\"\($0.wrong)\" → \"\($0.right)\"" }
+                .joined(separator: "\n")
+            sections.append(
+                "Known misrecognitions from this user's dictation history — when the left side appears, it was almost certainly meant as the right side:\n"
+                    + lines
+                    + "\nApply a correction only where the misrecognized form actually occurs; never insert these terms anywhere else."
+            )
+        }
+        sections.append(base)
+        return sections.joined(separator: "\n\n")
+    }
+
     private static func rewriteWithKyma(
         token: String, text: String, systemPrompt: String
     ) async throws -> String {
@@ -295,19 +332,11 @@ enum STTProvider {
         request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
 
-        // Prepend the user's personal-dictionary terms as CONTEXT so the LLM
-        // corrects with context (won't turn "Caterpillar" into "Cat…") — a
-        // smarter, safer corrector than blind find-replace. Bare, frequency-
-        // ordered, capped (client-side request-body change only; the proxy is
-        // unchanged). See redesign/07-DICTATION-LEARNING.md §5 review C.
-        let glossary = PersonalDictionary.shared.glossaryTerms()
-        let system: String
-        if glossary.isEmpty {
-            system = systemPrompt
-        } else {
-            system = "The user's preferred spellings for names and terms (use these exact forms when they occur): "
-                + glossary.joined(separator: ", ") + ".\n\n" + systemPrompt
-        }
+        let system = rewriteSystemPrompt(
+            base: systemPrompt,
+            glossary: PersonalDictionary.shared.glossaryTerms(),
+            pairs: PersonalDictionary.shared.correctionPairs()
+        )
 
         let body: [String: Any] = [
             // Benchmarked 2026-06-10: gemini-2.5-flash 1.7s clean output;

--- a/Tests/RewritePromptTests.swift
+++ b/Tests/RewritePromptTests.swift
@@ -1,0 +1,89 @@
+import XCTest
+@testable import Haynoi
+
+/// v2 Phase 1: correction pairs feed the LLM rewrite pass as grounded few-shot
+/// context (redesign/10-DICTATION-LEARNING-V2.md). Covers the prompt builder,
+/// the activation gate on `correctionPairs`, and the invariant that `wrong`
+/// forms never leak into the STT-side glossary.
+final class RewritePromptTests: XCTestCase {
+
+    // MARK: - Prompt builder
+
+    func testEmptyDictionaryLeavesBasePromptUntouched() {
+        let base = "Clean up this dictated text."
+        XCTAssertEqual(STTProvider.rewriteSystemPrompt(base: base, glossary: [], pairs: []), base)
+    }
+
+    func testGlossaryOnlyKeepsLegacyShape() {
+        let system = STTProvider.rewriteSystemPrompt(
+            base: "BASE", glossary: ["Haynoi", "Sơn"], pairs: []
+        )
+        XCTAssertTrue(system.contains("preferred spellings"), "glossary section must be present")
+        XCTAssertTrue(system.contains("Haynoi, Sơn."))
+        XCTAssertTrue(system.hasSuffix("BASE"), "mode prompt must come last")
+        XCTAssertFalse(system.contains("misrecognitions"), "no pair section without pairs")
+    }
+
+    func testPairsRenderedAsGroundedFewShot() {
+        let system = STTProvider.rewriteSystemPrompt(
+            base: "BASE", glossary: ["Haynoi"],
+            pairs: [(wrong: "Hanoi", right: "Haynoi"), (wrong: "Afider", right: "Affitor")]
+        )
+        XCTAssertTrue(system.contains("\"Hanoi\" → \"Haynoi\""))
+        XCTAssertTrue(system.contains("\"Afider\" → \"Affitor\""))
+        // The grounding constraint is load-bearing (ungrounded fix-up passes
+        // over-correct) — its two halves must survive any future rewording pass.
+        XCTAssertTrue(system.contains("only where the misrecognized form actually occurs"))
+        XCTAssertTrue(system.contains("never insert these terms anywhere else"))
+        XCTAssertTrue(system.hasSuffix("BASE"))
+    }
+
+    // MARK: - correctionPairs activation gate
+
+    func testCorrectionPairsRespectTheActivationGate() {
+        let dict = PersonalDictionary.shared
+        var cleanup: [UUID] = []
+        defer { cleanup.forEach { dict.delete(id: $0) } }
+
+        // Manual replacement — always trusted, must appear.
+        if let e = dict.addReplacement(wrong: "pairGateManualW", right: "pairGateManualR") {
+            cleanup.append(e.id)
+        }
+        // Learned but unconfirmed (conf 1 < 2) — must NOT appear.
+        if let e = dict.upsertLearnedReplacement(
+            wrong: "pairGateLearnedW", right: "pairGateLearnedR", confirmations: 1
+        ) {
+            cleanup.append(e.id)
+        }
+        // Plain term — has no wrong form, must NOT appear.
+        if let e = dict.addTerm("pairGateTermR") {
+            cleanup.append(e.id)
+        }
+
+        let pairs = dict.correctionPairs(max: 100)
+        XCTAssertTrue(pairs.contains { $0.wrong == "pairGateManualW" && $0.right == "pairGateManualR" },
+                      "manual replacement must reach the LLM pass")
+        XCTAssertFalse(pairs.contains { $0.wrong == "pairGateLearnedW" },
+                       "unconfirmed learned rule must not reach the LLM either — same gate as the deterministic replace")
+        XCTAssertFalse(pairs.contains { $0.right == "pairGateTermR" },
+                       "a bare term has no wrong form and is not a pair")
+    }
+
+    // MARK: - Invariant: wrong forms never reach the STT-side glossary
+
+    /// The STT `prompt` is prior-text conditioning — a `wrong` form there would
+    /// bias the decoder TOWARD the error. Pairs go only to the rewrite pass.
+    func testWrongFormsNeverLeakIntoSTTGlossary() {
+        let dict = PersonalDictionary.shared
+        var cleanup: [UUID] = []
+        defer { cleanup.forEach { dict.delete(id: $0) } }
+
+        if let e = dict.addReplacement(wrong: "leakTestWrongZqx", right: "leakTestRightZqx") {
+            cleanup.append(e.id)
+        }
+
+        XCTAssertFalse(dict.glossaryTerms(maxChars: 10_000).contains("leakTestWrongZqx"))
+        XCTAssertTrue(dict.glossaryTerms(maxChars: 10_000).contains("leakTestRightZqx"))
+        XCTAssertFalse(CustomDictionary.promptFragment.contains("leakTestWrongZqx"))
+    }
+}


### PR DESCRIPTION
Learning v2, Phase 1 (design: `redesign/10-DICTATION-LEARNING-V2.md`, local): the AI rewrite pass now sees the user's confirmed correction history, not just a bare glossary.

## What changed
- `PersonalDictionary.correctionPairs(max:)` — confirmed (wrong → right) pairs, frequency-ordered, capped at 10. Same activation gate as the deterministic replace (`firesAsReplacement`): manual rules always, learned rules only at ≥2 confirmations. No parallel trust path.
- `STTProvider.rewriteSystemPrompt(base:glossary:pairs:)` — extracted, testable prompt builder. Order: glossary → correction pairs as grounded few-shot lines → mode prompt. The constraint "apply only where the misrecognized form actually occurs; never insert these terms anywhere else" is load-bearing: an ungrounded LLM fix-up pass over-corrects.
- Invariant kept and now tested: `wrong` forms go **only** to the chat pass — never the STT `prompt`, where prior-text conditioning would bias the decoder *toward* the error.

## Why this works (spike, 2026-08-29, production models)
On a synthetic clip mentioning Haynoi/Mandeck/Affitor/Sơn, the quality-tier model produced "Hanoi", "Mandec", "Afider":
- STT `prompt` glossary fixed Mandeck/Affitor/Sơn but **not** "Hanoi" → "Haynoi" — the common word wins the acoustic tie. That's the biasing ceiling.
- The rewrite pass with correction pairs fixed **4/4**, including the case biasing lost.

Also from the spike: the `keywords` transcription param is accepted but inert through the gateway (dropped from the roadmap), and `include[]=logprobs` returns no logprobs yet (Phase 3 blocked on a Kyma-side passthrough).

## Tests
- New `RewritePromptTests` (5): prompt builder shape, activation gate on `correctionPairs`, wrong-forms-never-in-STT-glossary invariant.
- Full suite: **34/34 passed**.

## Scope note
`needsRewrite` is `.email`-only today, so this lands in Email mode first; Phase 3 (confidence-gated correction) is what extends it to Normal mode without paying LLM latency on every dictation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ
