### PR TITLE
feat(learning): trust controls — master switch, learned counter, forget-all

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can't — like a personal name that sounds identical to a common word. Only
   fixes you've confirmed are used, and they never leave your dictionary except
   inside the dictation being cleaned up.
+- **You're in charge of what Haynoi learns.** The Dictionary tab now has a
+  master switch for learning from your corrections, shows how many words
+  Haynoi has learned from you, and a "Forget all" button that wipes every
+  auto-learned word in one tap — words you added yourself are kept. Turning
+  learning off never breaks what's already learned; it only stops new
+  suggestions.
 - **Other audio gets out of the way while you dictate.** Music and video pause
   and resume on their own. A live call, stream or screen recording is dipped in
   volume instead — never paused, because there is nothing to resume. Haynoi

--- a/Sources/Haynoi/App/HaynoiApp.swift
+++ b/Sources/Haynoi/App/HaynoiApp.swift
@@ -750,6 +750,7 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             "hotkeyChoice": "option",  // founder default: left Option push-to-talk
             "fixThatHotkeyChoice": "ctrlOption", // v1.1: ⌃⌥ chord tap (never collides with PTT)
             "signalAEnabled": true,    // v1.3: learn when you edit a word in-app (AX-cooperative apps only)
+            "learningEnabled": true,   // v2 Phase 5: master switch for correction capture (A/B/C)
             "shareUsageData": true,    // analytics opt-out (default ON) — metadata only, never content
         ])
         NSLog("[Haynoi] App launched")

--- a/Sources/Haynoi/App/PipelineController.swift
+++ b/Sources/Haynoi/App/PipelineController.swift
@@ -339,7 +339,8 @@ final class PipelineController {
                 // .replacement (low confidence, can't corrupt output). Suggest-never-
                 // silent: the toast only adds on tap, suppressed in live contexts.
                 await MainActor.run {
-                    if let s = CorrectionDetector.shared.observe(text),
+                    if LearningSettings.isEnabled,
+                       let s = CorrectionDetector.shared.observe(text),
                        !LiveContext.isActive() {
                         let right = s.right
                         FloatingBarController.shared.showLearnToast(
@@ -544,8 +545,10 @@ final class PipelineController {
                 _ = PersonalDictionary.shared.disableMatchingReplacement(wrong: w, right: reversed.right)
                 NSLog("[Haynoi] Self-heal: disabled reversed rule %@ → %@", w, reversed.right)
             } else {
-                // Propose learning — suppress the toast in live contexts (§5.1).
-                if !LiveContext.isActive() {
+                // Propose learning — suppress the toast in live contexts (§5.1)
+                // and when the learning master switch is off (the replace itself
+                // already happened above; only the capture is gated).
+                if LearningSettings.isEnabled, !LiveContext.isActive() {
                     let wrong = change.wrong
                     let right = change.right
                     FloatingBarController.shared.showLearnToast(

--- a/Sources/Haynoi/Settings/SettingsView.swift
+++ b/Sources/Haynoi/Settings/SettingsView.swift
@@ -601,6 +601,13 @@ private struct DictionaryEditor: View {
     @State private var rightField = ""
     @State private var wrongField = ""
     @State private var isReplacement = false
+    // v2 Phase 5 — trust controls: master capture switch + forget-all-learned.
+    @AppStorage(LearningSettings.key) private var learningEnabled = true
+    @State private var confirmForgetLearned = false
+
+    private var learnedCount: Int {
+        entries.filter { $0.source == .learned }.count
+    }
 
     private var canAdd: Bool {
         let r = rightField.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -613,6 +620,50 @@ private struct DictionaryEditor: View {
 
     var body: some View {
         SettingsCard {
+            // v2 Phase 5 — the Gboard bar: a visible switch for auto-learning and
+            // a delete-everything-learned control. Manual entries are untouched;
+            // existing rules keep working either way — only CAPTURE is gated.
+            SettingsRow(showDivider: true) {
+                HStack(spacing: C.s2) {
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text("Learn from my corrections")
+                            .font(.system(size: 13, weight: .medium))
+                            .foregroundStyle(Color.obsidianLabel(for: scheme))
+                        Text(learnedCount > 0
+                             ? "Haynoi has learned \(learnedCount) word\(learnedCount == 1 ? "" : "s") from you."
+                             : "Haynoi suggests new words when you fix a dictation.")
+                            .font(.system(size: 11))
+                            .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                    }
+
+                    Spacer()
+
+                    if learnedCount > 0 {
+                        Button("Forget all") { confirmForgetLearned = true }
+                            .font(.system(size: 11))
+                            .foregroundStyle(Color.obsidianLabel3(for: scheme))
+                            .buttonStyle(.plain)
+                    }
+
+                    Toggle("", isOn: $learningEnabled)
+                        .toggleStyle(.switch)
+                        .labelsHidden()
+                        .scaleEffect(0.7)
+                        .frame(width: 36)
+                }
+            }
+            .alert("Forget everything Haynoi learned?", isPresented: $confirmForgetLearned) {
+                Button("Forget \(learnedCount) word\(learnedCount == 1 ? "" : "s")", role: .destructive) {
+                    let removed = PersonalDictionary.shared.deleteAllLearned()
+                    // Metadata only: the count — never the term strings.
+                    Analytics.capture("dictionary_learned_cleared", ["count": removed])
+                    reload()
+                }
+                Button("Cancel", role: .cancel) {}
+            } message: {
+                Text("Words you added yourself are kept.")
+            }
+
             // Add row
             SettingsRow(showDivider: !entries.isEmpty) {
                 VStack(alignment: .leading, spacing: C.s2) {

--- a/Sources/Haynoi/System/CorrectionWatcher.swift
+++ b/Sources/Haynoi/System/CorrectionWatcher.swift
@@ -76,7 +76,7 @@ final class CorrectionWatcher {
     private init() {}
 
     private var isEnabled: Bool {
-        UserDefaults.standard.bool(forKey: Self.enabledKey)
+        LearningSettings.isEnabled && UserDefaults.standard.bool(forKey: Self.enabledKey)
     }
 
     // MARK: - Whitelist

--- a/Sources/Haynoi/System/PersonalDictionary.swift
+++ b/Sources/Haynoi/System/PersonalDictionary.swift
@@ -14,6 +14,26 @@ import Foundation
 // v1.1+. CustomDictionary remains as a compat shim (bottom of this file) so the
 // existing call sites keep compiling.
 
+// MARK: - Learning master switch
+
+/// Master kill-switch for correction CAPTURE — Signals A/B/C stop proposing new
+/// learned entries when off (v2 Phase 5, redesign/10-DICTATION-LEARNING-V2.md).
+/// USING the dictionary stays on: glossary biasing, the rewrite pass, and
+/// existing replacement rules are unaffected. "Fix that" still replaces text —
+/// only the learn-toast is silenced.
+enum LearningSettings {
+    static let key = "learningEnabled"
+
+    /// Defaults to true when the key was never written — deliberately NOT a bare
+    /// `bool(forKey:)`, which reads false before `register(defaults:)` runs (the
+    /// muteMusic fresh-install bug, CHANGELOG [Unreleased]).
+    static var isEnabled: Bool {
+        UserDefaults.standard.object(forKey: key) == nil
+            ? true
+            : UserDefaults.standard.bool(forKey: key)
+    }
+}
+
 // MARK: - Model
 
 /// A single dictionary row. `.term` biases recognition (soft); `.replacement`
@@ -323,6 +343,32 @@ final class PersonalDictionary {
         queue.sync {
             entries.removeAll { $0.id == id }
             persist()
+        }
+    }
+
+    /// Number of auto-learned entries — the "Haynoi has learned N words" counter.
+    var learnedCount: Int {
+        queue.sync { entries.filter { $0.source == .learned }.count }
+    }
+
+    /// Pure filter behind `deleteAllLearned` — split out so the invariant
+    /// (manual entries survive, learned entries go) is unit-testable without
+    /// touching the real on-disk dictionary.
+    static func removingLearned(_ entries: [DictionaryEntry]) -> [DictionaryEntry] {
+        entries.filter { $0.source != .learned }
+    }
+
+    /// The Gboard-bar "delete what you've learned" control (v2 Phase 5): removes
+    /// every `.learned` entry in one action; manual entries survive. Returns the
+    /// number removed.
+    @discardableResult
+    func deleteAllLearned() -> Int {
+        queue.sync {
+            let before = entries.count
+            entries = PersonalDictionary.removingLearned(entries)
+            let removed = before - entries.count
+            if removed > 0 { persist() }
+            return removed
         }
     }
 

--- a/Tests/RewritePromptTests.swift
+++ b/Tests/RewritePromptTests.swift
@@ -69,6 +69,41 @@ final class RewritePromptTests: XCTestCase {
                        "a bare term has no wrong form and is not a pair")
     }
 
+    // MARK: - v2 Phase 5: trust controls
+
+    /// Pure-filter invariant behind `deleteAllLearned`: learned entries go,
+    /// manual entries survive — tested WITHOUT touching the real dictionary.
+    func testRemovingLearnedKeepsManualEntries() {
+        let manual = DictionaryEntry(right: "Keep", kind: .term, source: .manual)
+        let learnedTerm = DictionaryEntry(right: "DropA", kind: .term, source: .learned)
+        let learnedRule = DictionaryEntry(right: "DropB", wrong: "dropb", kind: .replacement,
+                                          source: .learned, confirmations: 2)
+
+        let kept = PersonalDictionary.removingLearned([manual, learnedTerm, learnedRule])
+        XCTAssertEqual(kept.map(\.right), ["Keep"], "only the manual entry survives")
+    }
+
+    func testLearningSettingsDefaultsOnWhenKeyAbsent() {
+        let defaults = UserDefaults.standard
+        let original = defaults.object(forKey: LearningSettings.key)
+        defer {
+            // Restore whatever state the machine had (absent or an explicit bool).
+            if let original {
+                defaults.set(original, forKey: LearningSettings.key)
+            } else {
+                defaults.removeObject(forKey: LearningSettings.key)
+            }
+        }
+
+        defaults.removeObject(forKey: LearningSettings.key)
+        XCTAssertTrue(LearningSettings.isEnabled,
+                      "absent key must read as ON — the muteMusic fresh-install bug class")
+        defaults.set(false, forKey: LearningSettings.key)
+        XCTAssertFalse(LearningSettings.isEnabled)
+        defaults.set(true, forKey: LearningSettings.key)
+        XCTAssertTrue(LearningSettings.isEnabled)
+    }
+
     // MARK: - Invariant: wrong forms never reach the STT-side glossary
 
     /// The STT `prompt` is prior-text conditioning — a `wrong` form there would


### PR DESCRIPTION
Learning v2, Phase 5 (design: `redesign/10-DICTATION-LEARNING-V2.md`, local): clear the trust bar only Gboard currently meets — a visible learning toggle plus a delete-everything-learned control.

## What changed
- **Master switch** "Learn from my corrections" in the Dictionary tab (`learningEnabled`, default ON). Gates **capture only**: Signal A (AX read-back), Signal B (re-dictation), and Signal C ("fix that") stop proposing new entries. Glossary biasing, the rewrite pass, existing replacement rules, and the "fix that" in-place replace keep working.
- **Learned counter**: "Haynoi has learned N words from you." in the same row.
- **Forget all** (confirmed via alert): `PersonalDictionary.deleteAllLearned()` removes every `.learned` entry; manual entries survive. Emits `dictionary_learned_cleared` with the count only — never term strings.
- `LearningSettings.isEnabled` treats an absent key as ON instead of trusting `bool(forKey:)` — the muteMusic fresh-install bug class — and the key is additionally registered in defaults for the Settings binding.

## Tests
- New: pure-filter invariant (learned go, manual survive — tested without touching the real dictionary file) and the absent-key-reads-ON default.
- Full suite: **36/36 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ
