### PR TITLE
feat(learning): Signal E — logprob-gated correction pass

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can't — like a personal name that sounds identical to a common word. Only
   fixes you've confirmed are used, and they never leave your dictionary except
   inside the dictation being cleaned up.
+- **Haynoi notices when it wasn't sure.** When the transcriber flags doubt
+  about a word — exactly where names and jargon go wrong — that dictation
+  gets one extra pass through your personal fixes before the text is typed.
+  Confident dictations skip it entirely, so nothing gets slower. Works in
+  every mode once our servers finish rolling out the confidence signal.
 - **You're in charge of what Haynoi learns.** The Dictionary tab now has a
   master switch for learning from your corrections, shows how many words
   Haynoi has learned from you, and a "Forget all" button that wipes every

--- a/Sources/Haynoi/System/PersonalDictionary.swift
+++ b/Sources/Haynoi/System/PersonalDictionary.swift
@@ -351,6 +351,13 @@ final class PersonalDictionary {
         queue.sync { entries.filter { $0.source == .learned }.count }
     }
 
+    /// Whether there is any personal context to ground an LLM correction pass
+    /// (Signal E gate) — an ungrounded fix-up pass over-corrects, so without
+    /// this the pass must not run.
+    var hasGroundingContext: Bool {
+        !glossaryTerms().isEmpty || !correctionPairs(max: 1).isEmpty
+    }
+
     /// Pure filter behind `deleteAllLearned` — split out so the invariant
     /// (manual entries survive, learned entries go) is unit-testable without
     /// touching the real on-disk dictionary.

--- a/Sources/Haynoi/Transcription/STTProvider.swift
+++ b/Sources/Haynoi/Transcription/STTProvider.swift
@@ -68,15 +68,35 @@ enum STTProvider {
             }
         }
 
-        var text = try await callTranscribe(
+        let transcribed = try await callTranscribe(
             token: token, audio: audio, model: model, prompt: prompt,
             languageHint: languageHint
         )
+        var text = transcribed.text
 
         if mode.needsRewrite, !text.isEmpty {
             text = try await rewriteWithKyma(
                 token: token, text: text, systemPrompt: mode.rewritePrompt
             )
+        } else if !text.isEmpty,
+                  shouldRunCorrectionPass(
+                      needsRewrite: mode.needsRewrite,
+                      logprobs: transcribed.logprobs,
+                      hasGrounding: PersonalDictionary.shared.hasGroundingContext
+                  ) {
+            // Signal E (v2 Phase 3): the model itself flagged doubt on a token,
+            // so this dictation — and only this one — pays for a grounded
+            // correction pass. Modes with a rewrite already get the glossary +
+            // pairs there; this extends the same correction to rewrite-less
+            // modes without adding LLM latency to every dictation. Failure of
+            // the optional pass never fails the dictation.
+            text = (try? await rewriteWithKyma(
+                token: token, text: text, systemPrompt: Self.correctionPassPrompt
+            )) ?? text
+            // Metadata only: that the pass ran — never the text.
+            await MainActor.run {
+                Analytics.capture("stt_correction_pass", ["trigger": "logprobs"])
+            }
         }
         // Deterministic personal-dictionary replace runs LAST — after the LLM
         // rewrite (so the rewrite can't re-mangle a term we just fixed), or in
@@ -90,6 +110,39 @@ enum STTProvider {
         }
         return Result(text: text, firedIDs: firedIDs)
     }
+
+    // MARK: - Signal E: logprob-gated correction (v2 Phase 3)
+
+    /// A token logprob below this reads as "the model wasn't sure". Provisional
+    /// value (~37% probability) pending live logprob data from the gateway —
+    /// the field ships server-side in kyma-api#1074; until it's deployed,
+    /// `logprobs` is nil and the gate never opens.
+    static let lowConfidenceLogprob: Double = -1.0
+
+    /// True when at least one token fell below the confidence floor.
+    static func hasLowConfidenceToken(_ logprobs: [Double]) -> Bool {
+        logprobs.contains { $0 < lowConfidenceLogprob }
+    }
+
+    /// The correction pass runs only when ALL hold: the mode has no rewrite
+    /// (rewrite modes already carry the glossary + pairs), the model flagged a
+    /// doubtful token, and there is personal context to ground the fix — an
+    /// UNgrounded LLM fix-up pass over-corrects, so no grounding means no call.
+    static func shouldRunCorrectionPass(
+        needsRewrite: Bool, logprobs: [Double]?, hasGrounding: Bool
+    ) -> Bool {
+        guard !needsRewrite, hasGrounding, let logprobs else { return false }
+        return hasLowConfidenceToken(logprobs)
+    }
+
+    /// Base prompt for the correction-only pass. `rewriteSystemPrompt` places
+    /// the glossary and correction pairs ABOVE this, so "the context above"
+    /// resolves to exactly that grounding.
+    static let correctionPassPrompt = """
+        The text is a raw speech-to-text transcript. Fix misrecognized words \
+        using the context above. Change nothing else — no rephrasing, no \
+        formatting, no additions or removals. Return only the corrected text.
+        """
 
     /// Resolves the model alias from the user's quality setting. The proxy
     /// passes these verbatim to Kyma.
@@ -193,8 +246,14 @@ enum STTProvider {
     private static func callTranscribe(
         token: String, audio: EncodedAudio, model: String, prompt: String,
         languageHint: String
-    ) async throws -> String {
+    ) async throws -> (text: String, logprobs: [Double]?) {
         let boundary = UUID().uuidString
+        // Signal E: the quality tier supports per-token logprobs with the json
+        // format. Harmless before the gateway ships the passthrough — the
+        // response then simply carries no logprobs and the gate stays closed.
+        // The fast tier's model has no logprobs support; it keeps the default
+        // response shape.
+        let wantsLogprobs = model == "transcribe-quality"
 
         var body = Data()
         body.append("--\(boundary)\r\n")
@@ -224,6 +283,15 @@ enum STTProvider {
             body.append("\(languageHint)\r\n")
         }
 
+        if wantsLogprobs {
+            body.append("--\(boundary)\r\n")
+            body.append("Content-Disposition: form-data; name=\"response_format\"\r\n\r\n")
+            body.append("json\r\n")
+            body.append("--\(boundary)\r\n")
+            body.append("Content-Disposition: form-data; name=\"include[]\"\r\n\r\n")
+            body.append("logprobs\r\n")
+        }
+
         body.append("--\(boundary)--\r\n")
 
         var request = URLRequest(url: URL(string: transcribeURL)!)
@@ -246,7 +314,14 @@ enum STTProvider {
                       let text = json["text"] as? String else {
                     throw STTError.parseError
                 }
-                return text.trimmingCharacters(in: .whitespacesAndNewlines)
+                // Per-token confidence (Signal E) — present only when the
+                // gateway passes it through; absent = nil, gate stays closed.
+                var logprobs: [Double]?
+                if let entries = json["logprobs"] as? [[String: Any]] {
+                    let values = entries.compactMap { $0["logprob"] as? Double }
+                    if !values.isEmpty { logprobs = values }
+                }
+                return (text.trimmingCharacters(in: .whitespacesAndNewlines), logprobs)
             case 401:
                 // Session expired/revoked server-side — sign out locally and notify UI.
                 NSLog("[Haynoi] 401 from proxy — session expired, signing out")

--- a/Tests/CorrectionPassTests.swift
+++ b/Tests/CorrectionPassTests.swift
@@ -1,0 +1,60 @@
+import XCTest
+@testable import Haynoi
+
+/// v2 Phase 3 (Signal E): the logprob-gated correction pass. The gate must be
+/// closed unless ALL of: no rewrite mode, a low-confidence token, and grounding
+/// context — an ungrounded LLM fix-up pass over-corrects, and rewrite modes
+/// already carry the glossary + pairs.
+final class CorrectionPassTests: XCTestCase {
+
+    func testLowConfidenceDetector() {
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([]), "no data = no doubt signal")
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([-0.01, -0.2, -0.9]),
+                       "all tokens above the floor")
+        XCTAssertTrue(STTProvider.hasLowConfidenceToken([-0.01, -2.4, -0.2]),
+                      "one doubtful token opens the gate")
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([STTProvider.lowConfidenceLogprob]),
+                       "the floor itself is not below the floor")
+    }
+
+    func testGateClosedWithoutLogprobs() {
+        XCTAssertFalse(STTProvider.shouldRunCorrectionPass(
+            needsRewrite: false, logprobs: nil, hasGrounding: true),
+            "gateway not shipping logprobs yet → dormant")
+    }
+
+    func testGateClosedForRewriteModes() {
+        XCTAssertFalse(STTProvider.shouldRunCorrectionPass(
+            needsRewrite: true, logprobs: [-3.0], hasGrounding: true),
+            "rewrite modes already carry glossary + pairs — never pay twice")
+    }
+
+    func testGateClosedWithoutGrounding() {
+        XCTAssertFalse(STTProvider.shouldRunCorrectionPass(
+            needsRewrite: false, logprobs: [-3.0], hasGrounding: false),
+            "ungrounded LLM correction over-corrects — no grounding, no call")
+    }
+
+    func testGateClosedWhenConfident() {
+        XCTAssertFalse(STTProvider.shouldRunCorrectionPass(
+            needsRewrite: false, logprobs: [-0.1, -0.3], hasGrounding: true))
+    }
+
+    func testGateOpensOnlyWhenAllConditionsHold() {
+        XCTAssertTrue(STTProvider.shouldRunCorrectionPass(
+            needsRewrite: false, logprobs: [-0.1, -2.2], hasGrounding: true))
+    }
+
+    func testCorrectionPromptComposesUnderGrounding() {
+        let system = STTProvider.rewriteSystemPrompt(
+            base: STTProvider.correctionPassPrompt,
+            glossary: ["Haynoi"],
+            pairs: [(wrong: "Hanoi", right: "Haynoi")]
+        )
+        XCTAssertTrue(system.hasSuffix(STTProvider.correctionPassPrompt),
+                      "grounding sections must sit ABOVE the correction instruction")
+        XCTAssertTrue(system.contains("\"Hanoi\" → \"Haynoi\""))
+        XCTAssertTrue(STTProvider.correctionPassPrompt.contains("Change nothing else"),
+                      "the no-rephrasing constraint is load-bearing")
+    }
+}


### PR DESCRIPTION
Learning v2, Phase 3 (Signal E): confidence-gated correction — the whitespace no competitor fills (error *detection* is 100% human across the entire market).

## What changed
- Quality-tier transcription now sends `response_format=json` + `include[]=logprobs`.
- New gate `shouldRunCorrectionPass`: opens only when ALL hold — the mode has no rewrite (rewrite modes already carry glossary + pairs), at least one token logprob fell below `-1.0` (provisional threshold pending live data), and the user has grounding context (glossary or confirmed pairs). An ungrounded LLM fix-up pass over-corrects, so no grounding = no call.
- When open, that one dictation pays for a single grounded correction pass — `rewriteSystemPrompt` with a correction-only base ("Fix misrecognized words using the context above. Change nothing else…"). Failure of the optional pass never fails the dictation.
- Net effect once server-side lands: Normal/Clean modes get the Phase-1 correction quality **without** adding LLM latency to every dictation — only the dictations the model itself doubted.

## Dormant by design
Server prerequisite is kyma-api#1074 (logprobs passthrough). Until that deploys, the response carries no `logprobs`, the gate never opens, and behavior is byte-identical to today — the `json` response shape was already proven live in the Phase-0 spike. Ship order is safe in either direction.

## Tests
- New `CorrectionPassTests` (7): detector, every gate leg (no logprobs / rewrite mode / no grounding / confident), and prompt composition (grounding above the no-rephrasing constraint).
- Full suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ
