### PR TITLE
fix(learning): tune Signal E threshold from live logprob measurement

### DIFF
--- a/Sources/Haynoi/Transcription/STTProvider.swift
+++ b/Sources/Haynoi/Transcription/STTProvider.swift
@@ -113,11 +113,16 @@ enum STTProvider {
 
     // MARK: - Signal E: logprob-gated correction (v2 Phase 3)
 
-    /// A token logprob below this reads as "the model wasn't sure". Provisional
-    /// value (~37% probability) pending live logprob data from the gateway —
-    /// the field ships server-side in kyma-api#1074; until it's deployed,
-    /// `logprobs` is nil and the gate never opens.
-    static let lowConfidenceLogprob: Double = -1.0
+    /// A token logprob below this reads as "the model wasn't sure". Tuned from
+    /// live gateway data (2026-08-29, clean clip): correct tokens sit at
+    /// ~-0.0001…-0.006 while misrecognized names measured -0.25…-1.11
+    /// ("Sun" -0.91, "Mand"/"ec" -0.25/-0.40, "Af"/"iter" -0.37/-1.11) — the
+    /// original -1.0 caught only one of four errors. -0.3 catches all but the
+    /// confidently-wrong class ("Hanoi" for "Haynoi" measured -0.006), which no
+    /// confidence signal can see and the deterministic replace handles instead.
+    /// Watch the `stt_correction_pass` PostHog rate for over-triggering on
+    /// noisy real-world audio before tightening further.
+    static let lowConfidenceLogprob: Double = -0.3
 
     /// True when at least one token fell below the confidence floor.
     static func hasLowConfidenceToken(_ logprobs: [Double]) -> Bool {

--- a/Tests/CorrectionPassTests.swift
+++ b/Tests/CorrectionPassTests.swift
@@ -8,13 +8,28 @@ import XCTest
 final class CorrectionPassTests: XCTestCase {
 
     func testLowConfidenceDetector() {
+        let floor = STTProvider.lowConfidenceLogprob
         XCTAssertFalse(STTProvider.hasLowConfidenceToken([]), "no data = no doubt signal")
-        XCTAssertFalse(STTProvider.hasLowConfidenceToken([-0.01, -0.2, -0.9]),
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([-0.001, floor + 0.05]),
                        "all tokens above the floor")
-        XCTAssertTrue(STTProvider.hasLowConfidenceToken([-0.01, -2.4, -0.2]),
+        XCTAssertTrue(STTProvider.hasLowConfidenceToken([-0.001, floor - 0.05]),
                       "one doubtful token opens the gate")
-        XCTAssertFalse(STTProvider.hasLowConfidenceToken([STTProvider.lowConfidenceLogprob]),
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([floor]),
                        "the floor itself is not below the floor")
+    }
+
+    /// Regression pin against the LIVE gateway measurement (2026-08-29) that
+    /// set the threshold: misrecognized name tokens measured -0.25…-1.11 and
+    /// must open the gate; correct tokens measured ≈-0.0001…-0.006 and must
+    /// not. "Hanoi" (confidently wrong at -0.006) is intentionally invisible
+    /// to this signal — the deterministic replace owns that class.
+    func testThresholdCatchesMeasuredErrorTokens() {
+        for measured in [-0.9093, -0.4039, -0.3689, -1.1107] {
+            XCTAssertTrue(STTProvider.hasLowConfidenceToken([measured]),
+                          "measured error token \(measured) must open the gate")
+        }
+        XCTAssertFalse(STTProvider.hasLowConfidenceToken([-0.0002, -0.0061, -0.0006]),
+                       "confident tokens (incl. the Hanoi-class error) stay closed")
     }
 
     func testGateClosedWithoutLogprobs() {
@@ -37,7 +52,9 @@ final class CorrectionPassTests: XCTestCase {
 
     func testGateClosedWhenConfident() {
         XCTAssertFalse(STTProvider.shouldRunCorrectionPass(
-            needsRewrite: false, logprobs: [-0.1, -0.3], hasGrounding: true))
+            needsRewrite: false,
+            logprobs: [-0.001, STTProvider.lowConfidenceLogprob + 0.05],
+            hasGrounding: true))
     }
 
     func testGateOpensOnlyWhenAllConditionsHold() {


### PR DESCRIPTION
The gateway now ships per-token logprobs (kyma-api#1074, deployed). Live measurement on the spike clip: correct tokens ≈ -0.0001…-0.006; misrecognized name tokens -0.25…-1.11. The provisional -1.0 floor caught 1 of 4 errors — -0.3 catches all except the confidently-wrong class ("Hanoi" for "Haynoi" at -0.006), which is invisible to any confidence signal and belongs to the deterministic replace.

Tests derive from the constant now + a regression pin on the measured values. Full suite passed. Watch `stt_correction_pass` in PostHog for over-triggering on noisy real audio.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ