### PR TITLE
feat(learning): Phase 4 — phonetic matching for doubtful words and Signal B

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   can't — like a personal name that sounds identical to a common word. Only
   fixes you've confirmed are used, and they never leave your dictionary except
   inside the dictation being cleaned up.
+- **Doubtful words are matched by sound against your dictionary.** When the
+  transcriber hesitates on a word that sounds like a name you use — "Afider"
+  for "Affitor", "Sun" for "Sơn" — Haynoi now hands the cleanup pass that
+  exact candidate instead of hoping it guesses right. Sound matching also
+  helps Haynoi recognize a re-dictated correction whose spelling differs a
+  lot from what was heard.
 - **Haynoi notices when it wasn't sure.** When the transcriber flags doubt
   about a word — exactly where names and jargon go wrong — that dictation
   gets one extra pass through your personal fixes before the text is typed.

--- a/Sources/Haynoi/System/CorrectionDetector.swift
+++ b/Sources/Haynoi/System/CorrectionDetector.swift
@@ -120,16 +120,18 @@ final class CorrectionDetector {
         // ("Hai Noi" → "Haynoi"), but cap both sides at 2 orthographic tokens.
         guard wrongTokens.count <= 2, rightTokens.count <= 2 else { return false }
 
-        // (a.4) Small per-token edit distance — near-homophone, not a different word.
-        // Compare the joined (spaces removed) forms so "Hai Noi" vs "Haynoi" reads as
-        // a 0-ish edit, not a whitespace blowup.
+        // (a.4) Near-homophone test on the joined (spaces removed) forms, so
+        // "Hai Noi" vs "Haynoi" reads as a 0-ish edit, not a whitespace blowup.
+        // Two ways to qualify (v2 Phase 4): small ORTHOGRAPHIC distance, OR the
+        // same PHONETIC key — which rescues sound-alike spellings whose letters
+        // diverge ("Kathryn"/"Catherine"-class names). Every other gate (single
+        // region, diacritic direction, stopword) still applies either way.
         let wrongJoined = wrong.replacingOccurrences(of: " ", with: "")
         let rightJoined = right.replacingOccurrences(of: " ", with: "")
-        guard levenshtein(wrongJoined.lowercased(), rightJoined.lowercased()) <= maxTokenEditDistanceConst else { return false }
-
-        // (a.4b) Similarity floor on the CHANGED region itself (joined forms) — the
-        // real near-homophone gate, independent of surrounding sentence length.
-        guard normalizedSimilarity(wrongJoined, rightJoined) >= 0.5 else { return false }
+        let orthoClose =
+            levenshtein(wrongJoined.lowercased(), rightJoined.lowercased()) <= maxTokenEditDistanceConst
+            && normalizedSimilarity(wrongJoined, rightJoined) >= 0.5
+        guard orthoClose || Phonetics.close(wrongJoined, rightJoined) else { return false }
 
         // (b) Diacritic-direction asymmetry: qualify ONLY when `right` ADDS
         // diacritics / structure that `wrong` lacked — never the reverse.

--- a/Sources/Haynoi/System/PersonalDictionary.swift
+++ b/Sources/Haynoi/System/PersonalDictionary.swift
@@ -358,6 +358,26 @@ final class PersonalDictionary {
         !glossaryTerms().isEmpty || !correctionPairs(max: 1).isEmpty
     }
 
+    /// Dictionary `right` forms that sound like `word` (v2 Phase 4) — named
+    /// candidates for a low-confidence span, fed to the correction pass as a
+    /// targeted hint. Sound-alike only; never applied as a replacement.
+    func phoneticCandidates(for word: String, max limit: Int = 3) -> [String] {
+        let trimmed = word.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return [] }
+        var seen = Set<String>()
+        var result: [String] = []
+        for entry in enabledEntries(kinds: [.term, .replacement])
+            .sorted(by: { $0.frequency > $1.frequency }) {
+            let right = entry.right.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !right.isEmpty, seen.insert(right.lowercased()).inserted else { continue }
+            if Phonetics.close(trimmed, right) {
+                result.append(right)
+                if result.count >= limit { break }
+            }
+        }
+        return result
+    }
+
     /// Pure filter behind `deleteAllLearned` — split out so the invariant
     /// (manual entries survive, learned entries go) is unit-testable without
     /// touching the real on-disk dictionary.

--- a/Sources/Haynoi/System/Phonetics.swift
+++ b/Sources/Haynoi/System/Phonetics.swift
@@ -1,0 +1,112 @@
+import Foundation
+
+// MARK: - Phonetics (v2 Phase 4 — sound-alike matching)
+//
+// A compact phonetic key for VI + EN words, built for ONE job: deciding whether
+// two spellings could be the same spoken word ("Afider"/"Affitor",
+// "Xero"/"Zero", "trương"/"chương"). Not IPA, not linguistics — a consonant
+// skeleton where letters the transcriber commonly confuses share a symbol.
+//
+// Vietnamese is treated tone- and vowel-quality-insensitively on purpose: tones
+// and diacritic vowel quality are exactly what a misrecognition mangles, so
+// they must not separate a wrong form from its intended form. The diacritic
+// DIRECTION safety lives in CorrectionDetector's gates, not here.
+//
+// Phonetic proximity NEVER auto-promotes anything to a `.replacement` — it only
+// widens Signal B's near-homophone net and names candidates for the Signal E
+// correction pass (redesign/10-DICTATION-LEARNING-V2.md Phase 4).
+enum Phonetics {
+
+    /// Phonetic key of a word or short phrase (spaces ignored). Examples:
+    /// "Sơn"/"Sun"/"Son" → "sn" · "Hà Nội"/"Haynoi"/"Hai Noi" → "an" ·
+    /// "Affitor"/"Afider" → "aftr" · "Xero"/"Zero" → "sr" · "Eric"/"Erik" → "ark".
+    static func key(for term: String) -> String {
+        // Normalize: lowercase, đ→d, strip combining marks, letters only.
+        let lowered = term.lowercased().replacingOccurrences(of: "đ", with: "d")
+        let stripped = lowered.decomposedStringWithCanonicalMapping.unicodeScalars
+            .filter { $0.properties.canonicalCombiningClass == .notReordered }
+        let letters = String(String.UnicodeScalarView(stripped)).filter { $0.isLetter }
+        let chars = Array(letters)
+
+        var out: [Character] = []
+        var i = 0
+        func emit(_ c: Character) {
+            if out.last != c { out.append(c) }  // collapse doubles
+        }
+        while i < chars.count {
+            // Multi-letter units first (longest match wins).
+            if matches(chars, at: i, "ngh") { emit("n"); i += 3; continue }
+            if matches(chars, at: i, "ng") { emit("n"); i += 2; continue }
+            if matches(chars, at: i, "gh") { emit("k"); i += 2; continue }
+            if matches(chars, at: i, "ph") { emit("f"); i += 2; continue }
+            if matches(chars, at: i, "tr") { emit("c"); i += 2; continue }
+            if matches(chars, at: i, "ch") { emit("c"); i += 2; continue }
+
+            let c = chars[i]
+            let next: Character? = i + 1 < chars.count ? chars[i + 1] : nil
+            switch c {
+            case "a", "e", "i", "o", "u", "y":
+                // Vowels carry the confusion, not the identity: keep only a
+                // word-initial vowel marker, drop the rest.
+                if out.isEmpty { out.append("a") }
+            case "h", "w":
+                break  // weak/glide — contributes nothing to the skeleton
+            case "c":
+                emit(next.map { "eiy".contains($0) } == true ? "s" : "k")
+            case "g":
+                emit(next.map { "eiy".contains($0) } == true ? "j" : "k")
+            case "b", "p":
+                emit("p")
+            case "d", "t":
+                emit("t")
+            case "s", "z", "x":
+                emit("s")
+            case "f", "v":
+                emit("f")
+            case "k", "q":
+                emit("k")
+            default:
+                emit(c)  // j l m n r and anything else keep themselves
+            }
+            i += 1
+        }
+        return String(out)
+    }
+
+    private static func matches(_ chars: [Character], at i: Int, _ pattern: String) -> Bool {
+        let p = Array(pattern)
+        guard i + p.count <= chars.count else { return false }
+        for (offset, pc) in p.enumerated() where chars[i + offset] != pc { return false }
+        return true
+    }
+
+    /// Could `a` and `b` be the same spoken word? Equal keys, or one slip in a
+    /// key long enough that a single slip doesn't mean a different word.
+    static func close(_ a: String, _ b: String) -> Bool {
+        let ka = key(for: a)
+        let kb = key(for: b)
+        guard !ka.isEmpty, !kb.isEmpty else { return false }
+        if ka == kb { return true }
+        guard max(ka.count, kb.count) >= 3 else { return false }
+        return editDistance(ka, kb) <= 1
+    }
+
+    /// Tiny local Levenshtein — keys are a handful of characters, and
+    /// CorrectionDetector's copy is MainActor-isolated with its class.
+    private static func editDistance(_ a: String, _ b: String) -> Int {
+        let s = Array(a), t = Array(b)
+        if s.isEmpty { return t.count }
+        if t.isEmpty { return s.count }
+        var prev = Array(0...t.count)
+        var curr = [Int](repeating: 0, count: t.count + 1)
+        for i in 1...s.count {
+            curr[0] = i
+            for j in 1...t.count {
+                let cost = s[i - 1] == t[j - 1] ? 0 : 1
+                curr[j] = min(prev[j] + 1, curr[j - 1] + 1, prev[j - 1] + cost)
+            }
+            swap(&prev, &curr)
+        }
+        return prev[t.count]
+    }
+}

--- a/Sources/Haynoi/Transcription/STTProvider.swift
+++ b/Sources/Haynoi/Transcription/STTProvider.swift
@@ -81,7 +81,7 @@ enum STTProvider {
         } else if !text.isEmpty,
                   shouldRunCorrectionPass(
                       needsRewrite: mode.needsRewrite,
-                      logprobs: transcribed.logprobs,
+                      logprobs: transcribed.logprobs?.map(\.logprob),
                       hasGrounding: PersonalDictionary.shared.hasGroundingContext
                   ) {
             // Signal E (v2 Phase 3): the model itself flagged doubt on a token,
@@ -90,8 +90,19 @@ enum STTProvider {
             // pairs there; this extends the same correction to rewrite-less
             // modes without adding LLM latency to every dictation. Failure of
             // the optional pass never fails the dictation.
+            //
+            // v2 Phase 4: name the doubtful words and, when one sounds like a
+            // dictionary term, hand the LLM that candidate explicitly —
+            // "afider" → possibly "Affitor" — instead of hoping it connects
+            // the glossary to the right span on its own.
+            let doubtful = Self.doubtfulWords(from: transcribed.logprobs ?? [])
+            let hints = doubtful.compactMap { word -> (heard: String, candidates: [String])? in
+                let candidates = PersonalDictionary.shared.phoneticCandidates(for: word)
+                return candidates.isEmpty ? nil : (heard: word, candidates: candidates)
+            }
             text = (try? await rewriteWithKyma(
-                token: token, text: text, systemPrompt: Self.correctionPassPrompt
+                token: token, text: text, systemPrompt: Self.correctionPassPrompt,
+                hints: hints
             )) ?? text
             // Metadata only: that the pass ran — never the text.
             await MainActor.run {
@@ -127,6 +138,38 @@ enum STTProvider {
     /// True when at least one token fell below the confidence floor.
     static func hasLowConfidenceToken(_ logprobs: [Double]) -> Bool {
         logprobs.contains { $0 < lowConfidenceLogprob }
+    }
+
+    /// One transcription token with its confidence, as returned upstream.
+    struct TokenLogprob {
+        let token: String
+        let logprob: Double
+    }
+
+    /// Reconstructs whitespace-delimited words from the token stream and
+    /// returns the ones containing at least one token below the confidence
+    /// floor. Tokens concatenate to the transcript; a token beginning with
+    /// whitespace starts a new word (" Af" + "iter" is one word, " and"
+    /// starts the next). Edge punctuation is trimmed so "Hanoi." → "Hanoi".
+    static func doubtfulWords(from tokens: [TokenLogprob]) -> [String] {
+        var words: [(text: String, minLogprob: Double)] = []
+        var current = ""
+        var currentMin = 0.0
+        func flush() {
+            let cleaned = current
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .trimmingCharacters(in: .punctuationCharacters)
+            if !cleaned.isEmpty { words.append((cleaned, currentMin)) }
+            current = ""
+            currentMin = 0
+        }
+        for t in tokens {
+            if t.token.first?.isWhitespace == true, !current.isEmpty { flush() }
+            current += t.token
+            currentMin = min(currentMin, t.logprob)
+        }
+        flush()
+        return words.filter { $0.minLogprob < lowConfidenceLogprob }.map(\.text)
     }
 
     /// The correction pass runs only when ALL hold: the mode has no rewrite
@@ -251,7 +294,7 @@ enum STTProvider {
     private static func callTranscribe(
         token: String, audio: EncodedAudio, model: String, prompt: String,
         languageHint: String
-    ) async throws -> (text: String, logprobs: [Double]?) {
+    ) async throws -> (text: String, logprobs: [TokenLogprob]?) {
         let boundary = UUID().uuidString
         // Signal E: the quality tier supports per-token logprobs with the json
         // format. Harmless before the gateway ships the passthrough — the
@@ -321,9 +364,14 @@ enum STTProvider {
                 }
                 // Per-token confidence (Signal E) — present only when the
                 // gateway passes it through; absent = nil, gate stays closed.
-                var logprobs: [Double]?
+                // Tokens are kept alongside values so Phase 4 can name the
+                // doubtful WORDS, not just detect that doubt exists.
+                var logprobs: [TokenLogprob]?
                 if let entries = json["logprobs"] as? [[String: Any]] {
-                    let values = entries.compactMap { $0["logprob"] as? Double }
+                    let values = entries.compactMap { entry -> TokenLogprob? in
+                        guard let lp = entry["logprob"] as? Double else { return nil }
+                        return TokenLogprob(token: (entry["token"] as? String) ?? "", logprob: lp)
+                    }
                     if !values.isEmpty { logprobs = values }
                 }
                 return (text.trimmingCharacters(in: .whitespacesAndNewlines), logprobs)
@@ -379,7 +427,8 @@ enum STTProvider {
     static func rewriteSystemPrompt(
         base: String,
         glossary: [String],
-        pairs: [(wrong: String, right: String)]
+        pairs: [(wrong: String, right: String)],
+        hints: [(heard: String, candidates: [String])] = []
     ) -> String {
         var sections: [String] = []
         if !glossary.isEmpty {
@@ -398,12 +447,24 @@ enum STTProvider {
                     + "\nApply a correction only where the misrecognized form actually occurs; never insert these terms anywhere else."
             )
         }
+        if !hints.isEmpty {
+            // v2 Phase 4: doubtful spans matched phonetically against the
+            // user's dictionary — a targeted hint, still the LLM's call.
+            let lines = hints
+                .map { "\"\($0.heard)\" → possibly \($0.candidates.joined(separator: " or "))" }
+                .joined(separator: "\n")
+            sections.append(
+                "The transcriber was UNSURE of these words, and each sounds like a term this user actually uses — prefer the listed form when it fits the context:\n"
+                    + lines
+            )
+        }
         sections.append(base)
         return sections.joined(separator: "\n\n")
     }
 
     private static func rewriteWithKyma(
-        token: String, text: String, systemPrompt: String
+        token: String, text: String, systemPrompt: String,
+        hints: [(heard: String, candidates: [String])] = []
     ) async throws -> String {
         let url = URL(string: rewriteURL)!
         var request = URLRequest(url: url)
@@ -415,7 +476,8 @@ enum STTProvider {
         let system = rewriteSystemPrompt(
             base: systemPrompt,
             glossary: PersonalDictionary.shared.glossaryTerms(),
-            pairs: PersonalDictionary.shared.correctionPairs()
+            pairs: PersonalDictionary.shared.correctionPairs(),
+            hints: hints
         )
 
         let body: [String: Any] = [

--- a/Tests/PhoneticsTests.swift
+++ b/Tests/PhoneticsTests.swift
@@ -1,0 +1,106 @@
+import XCTest
+@testable import Haynoi
+
+/// v2 Phase 4: phonetic keys, doubtful-word reconstruction, dictionary
+/// candidates, and the Signal B phonetic widening.
+@MainActor
+final class PhoneticsTests: XCTestCase {
+
+    // MARK: - Keys
+
+    func testSoundAlikeSpellingsShareAKey() {
+        // The real confusion pairs this feature exists for.
+        XCTAssertEqual(Phonetics.key(for: "Sơn"), Phonetics.key(for: "Sun"))
+        XCTAssertEqual(Phonetics.key(for: "Sơn"), Phonetics.key(for: "Son"))
+        XCTAssertEqual(Phonetics.key(for: "Hà Nội"), Phonetics.key(for: "Haynoi"))
+        XCTAssertEqual(Phonetics.key(for: "Hà Nội"), Phonetics.key(for: "Hai Noi"))
+        XCTAssertEqual(Phonetics.key(for: "Affitor"), Phonetics.key(for: "Afider"))
+        XCTAssertEqual(Phonetics.key(for: "Xero"), Phonetics.key(for: "Zero"))
+        XCTAssertEqual(Phonetics.key(for: "Eric"), Phonetics.key(for: "Erik"))
+        XCTAssertEqual(Phonetics.key(for: "Mandeck"), Phonetics.key(for: "Mandec"))
+        // VN tr/ch merge — tone- and vowel-quality-insensitive by design.
+        XCTAssertEqual(Phonetics.key(for: "trương"), Phonetics.key(for: "chương"))
+    }
+
+    func testDifferentWordsStayApart() {
+        XCTAssertFalse(Phonetics.close("mèo", "Hà Nội"))
+        XCTAssertFalse(Phonetics.close("cat", "dog"))
+        XCTAssertFalse(Phonetics.close("", "Sơn"))
+    }
+
+    // MARK: - Doubtful-word reconstruction (real measured token stream)
+
+    func testDoubtfulWordsFromMeasuredTokenStream() {
+        // Verbatim from the 2026-08-29 live measurement. Floor is -0.3.
+        let tokens: [STTProvider.TokenLogprob] = [
+            .init(token: " for", logprob: -0.0000),
+            .init(token: " Hanoi", logprob: -0.0061),   // confidently WRONG — invisible here
+            .init(token: ".", logprob: -0.0000),
+            .init(token: " My", logprob: -0.0000),
+            .init(token: " Sun", logprob: -0.9093),      // doubtful
+            .init(token: " building", logprob: -0.0000),
+            .init(token: " Mand", logprob: -0.2523),
+            .init(token: "ec", logprob: -0.4039),        // same word, doubtful token
+            .init(token: " and", logprob: -0.0006),
+            .init(token: " Af", logprob: -0.3689),
+            .init(token: "iter", logprob: -1.1107),
+            .init(token: ".", logprob: -0.0000),
+        ]
+        let doubtful = STTProvider.doubtfulWords(from: tokens)
+        XCTAssertEqual(doubtful, ["Sun", "Mandec", "Afiter"],
+                       "multi-token words reassemble, punctuation trims, confident words stay out")
+    }
+
+    func testDoubtfulWordsEmptyWhenAllConfident() {
+        let tokens: [STTProvider.TokenLogprob] = [
+            .init(token: "This", logprob: -0.0002),
+            .init(token: " is", logprob: 0.0),
+        ]
+        XCTAssertTrue(STTProvider.doubtfulWords(from: tokens).isEmpty)
+    }
+
+    // MARK: - Dictionary candidates
+
+    func testPhoneticCandidatesMatchDictionaryTerms() {
+        let dict = PersonalDictionary.shared
+        var cleanup: [UUID] = []
+        defer { cleanup.forEach { dict.delete(id: $0) } }
+        if let e = dict.addTerm("PhonCandAffitor") { cleanup.append(e.id) }
+
+        XCTAssertTrue(dict.phoneticCandidates(for: "foncandafider").contains("PhonCandAffitor"),
+                      "a sound-alike misrecognition finds the dictionary term")
+        XCTAssertTrue(dict.phoneticCandidates(for: "zzqqxx").isEmpty)
+    }
+
+    // MARK: - Hint section in the correction prompt
+
+    func testHintsRenderIntoSystemPrompt() {
+        let system = STTProvider.rewriteSystemPrompt(
+            base: "BASE", glossary: [], pairs: [],
+            hints: [(heard: "Afiter", candidates: ["Affitor"])]
+        )
+        XCTAssertTrue(system.contains("\"Afiter\" → possibly Affitor"))
+        XCTAssertTrue(system.contains("UNSURE"))
+        XCTAssertTrue(system.hasSuffix("BASE"))
+        // No hints → no section.
+        XCTAssertFalse(STTProvider.rewriteSystemPrompt(base: "BASE", glossary: [], pairs: [])
+            .contains("UNSURE"))
+    }
+
+    // MARK: - Signal B phonetic widening
+
+    func testOrthographicallyFarButPhoneticallyEqualPairQualifies() {
+        // Synthetic long name: joined edit distance exceeds the ortho cap (4),
+        // but the phonetic keys agree within one slip — the widening path.
+        // Direction gate satisfied: `right` adds a diacritic + a capital.
+        XCTAssertTrue(CorrectionDetector.qualifiesAsLearnable(
+            wrong: "kolaborayshun", right: "Collaborâtion"))
+    }
+
+    func testPhoneticWideningNeverBypassesDirectionGate() {
+        // Same sounds, but `right` STRIPS the diacritic — the self-poisoning
+        // direction must stay blocked no matter how close the phonetics are.
+        XCTAssertFalse(CorrectionDetector.qualifiesAsLearnable(
+            wrong: "Sơn", right: "Son"))
+    }
+}


### PR DESCRIPTION
Learning v2, Phase 4: sound-alike matching — the layer that connects a doubtful word to the dictionary term it was meant to be.

## What changed
- **`Phonetics`** (new): a compact VI+EN phonetic key — consonant skeleton, tone- and vowel-quality-insensitive, ASR-confusable letters share a symbol (d/t, s/z/x, b/p, f/v, c/k/q, tr/ch, ng/n). `Sơn`/`Sun`/`Son`, `Hà Nội`/`Haynoi`/`Hai Noi`, `Affitor`/`Afider`, `Xero`/`Zero`, `trương`/`chương` all key identically.
- **Signal E now names its doubts**: logprob parsing keeps tokens, `doubtfulWords()` reassembles the low-confidence words (" Af"+"iter" → "Afiter"), and each is matched phonetically against dictionary right-forms via `PersonalDictionary.phoneticCandidates`. The correction pass receives targeted hints — `"Afiter" → possibly Affitor` — instead of hoping the LLM connects the glossary to the right span on its own.
- **Signal B widens**: a changed region qualifies on small orthographic distance OR matching phonetic keys, rescuing sound-alike names whose spelling diverges past the edit-distance cap. All other gates (single region, diacritic direction, stopword) still apply — phonetics never bypasses the anti-poisoning direction gate and never promotes anything to a `.replacement`.

## Tests
8 new (`PhoneticsTests`), including reassembly of the real measured token stream from the 2026-08-29 live spike and an explicit direction-gate-bypass check. Full suite **46/46 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ
