### PR TITLE
chore(release): prep 0.3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Haynoi are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.8] - 2026-08-29
 
 ### Added
 - **Your corrections now teach the AI cleanup pass.** When a mode runs the AI

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -88,6 +88,21 @@
   <div class="log-wrap">
     <article class="release">
       <div class="release-head">
+        <span class="release-version">0.3.8</span>
+        <span class="release-date">August 29, 2026</span>
+      </div>
+      <p class="release-tagline">It gets out of your way — and learns you.</p>
+      <ul>
+        <li>Other audio steps aside while you dictate: music and video pause and resume on their own; a live call or stream is dipped in volume instead — decided from what your Mac is actually playing, never a blind guess.</li>
+        <li>Your corrections now teach the AI cleanup pass. Fixes you've confirmed — like a name that sounds identical to a common word — are repaired automatically next time.</li>
+        <li>Haynoi notices when the transcriber wasn't sure of a word and gives that one dictation an extra pass through your personal fixes, matched by sound. Confident dictations skip it, so nothing gets slower.</li>
+        <li>You're in charge of what Haynoi learns: a master switch, a learned-words counter, and a one-tap "Forget all" in the Dictionary tab. Words you added yourself are always kept.</li>
+        <li>Fixed: scrolling froze for a moment right after every dictation, and "Pause audio while dictating" never ran on a fresh install.</li>
+      </ul>
+    </article>
+
+    <article class="release">
+      <div class="release-head">
         <span class="release-version">0.3.7</span>
         <span class="release-date">July 5, 2026</span>
       </div>


### PR DESCRIPTION
Stamps CHANGELOG [Unreleased] → [0.3.8] - 2026-08-29 (5 user-facing entries: audio focus, correction-pair cleanup, confidence pass + sound matching, trust controls, scroll-freeze/fresh-install fixes) and adds the matching haynoi.com changelog entry. Tag v0.3.8 follows the merge — CI builds, signs, notarizes, and publishes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ