### PR TITLE
fix(app): 0.3.8 reopen crash — windows freed behind ARC's back (0.3.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to Haynoi are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.9] - 2026-08-29
+
+### Fixed
+- Reopening the main window after closing it could crash the app (a window
+  memory-management bug present since the first releases, surfaced by 0.3.8).
+  Every window now has a single, correct owner.
+
 ## [0.3.8] - 2026-08-29
 
 ### Added

--- a/Sources/Haynoi/App/HaynoiApp.swift
+++ b/Sources/Haynoi/App/HaynoiApp.swift
@@ -909,6 +909,13 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             backing: .buffered,
             defer: false
         )
+        // A programmatic NSWindow defaults to isReleasedWhenClosed = true:
+        // AppKit sends an extra release when the user closes it, behind ARC's
+        // back, and `mainWindow` becomes a dangling pointer. The next
+        // showMainWindowPublic() then crashes in objc_retain touching
+        // window.isVisible — the 0.3.8 release-day crash (2026-08-29, first
+        // reopen after closing the main window). ARC must be the only owner.
+        window.isReleasedWhenClosed = false
         window.title = "Haynoi"
         window.appearance = Self.themeAppearance()
         window.contentView = NSHostingView(rootView: contentView)
@@ -978,6 +985,9 @@ class AppDelegate: NSObject, NSApplicationDelegate, UNUserNotificationCenterDele
             backing: .buffered,
             defer: false
         )
+        // Same over-release hazard as the main window (see showMainWindowPublic):
+        // this one is user-closable AND close()d programmatically.
+        window.isReleasedWhenClosed = false
         // Hidden titlebar: window chrome present (draggable) but no visible title bar text
         window.titlebarAppearsTransparent = true
         window.titleVisibility = .hidden

--- a/Sources/Haynoi/UI/FloatingBar.swift
+++ b/Sources/Haynoi/UI/FloatingBar.swift
@@ -57,6 +57,9 @@ class FloatingBarController {
             defer: false
         )
         win.contentView = hosting
+        // ARC owns this window — never let a stray close() free it behind our
+        // reference (the 0.3.8 main-window over-release class of crash).
+        win.isReleasedWhenClosed = false
         win.isOpaque = false
         win.backgroundColor = .clear
         win.level = .floating
@@ -141,6 +144,9 @@ class FloatingBarController {
             defer: false
         )
         win.contentView = hosting
+        // ARC owns this window — never let a stray close() free it behind our
+        // reference (the 0.3.8 main-window over-release class of crash).
+        win.isReleasedWhenClosed = false
         win.isOpaque = false
         win.backgroundColor = .clear
         win.level = .floating

--- a/project.yml
+++ b/project.yml
@@ -33,8 +33,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sonpiaz.haynoi
         PRODUCT_NAME: Haynoi
-        MARKETING_VERSION: "0.3.8"
-        CURRENT_PROJECT_VERSION: "30"
+        MARKETING_VERSION: "0.3.9"
+        CURRENT_PROJECT_VERSION: "31"
         INFOPLIST_FILE: Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Resources/Haynoi.entitlements
         SWIFT_VERSION: "5.9"

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -88,6 +88,17 @@
   <div class="log-wrap">
     <article class="release">
       <div class="release-head">
+        <span class="release-version">0.3.9</span>
+        <span class="release-date">August 29, 2026</span>
+      </div>
+      <p class="release-tagline">A same-day fix.</p>
+      <ul>
+        <li>Fixed a crash when reopening the main window after closing it — a long-standing window memory bug that 0.3.8 surfaced.</li>
+      </ul>
+    </article>
+
+    <article class="release">
+      <div class="release-head">
         <span class="release-version">0.3.8</span>
         <span class="release-date">August 29, 2026</span>
       </div>

--- a/version.env
+++ b/version.env
@@ -8,5 +8,5 @@
 #   - MARKETING_VERSION: semver-ish (MAJOR.MINOR.PATCH), user-visible
 #   - BUILD_NUMBER: monotonic integer, must increase every release
 
-MARKETING_VERSION=0.3.8
-BUILD_NUMBER=30
+MARKETING_VERSION=0.3.9
+BUILD_NUMBER=31


### PR DESCRIPTION
Symbolicated from the release-day crash report (EXC_BAD_ACCESS in objc_retain, AppDelegate.showMainWindowPublic): programmatic NSWindows default to isReleasedWhenClosed = true, so closing the main window freed it behind the strong reference, and the next reopen touched the dangling pointer. Present since the first releases; 0.3.8's release build surfaced it.

Fix: isReleasedWhenClosed = false at all four creation sites (main, onboarding, HUD, toast). Version bumped 0.3.9/31, CHANGELOG + site changelog stamped. Full suite passed. Tag v0.3.9 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ