### PR TITLE
fix(build): dev builds get their own bundle id — ends the TCC grant loop

### DIFF
--- a/Resources/Info.plist
+++ b/Resources/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>Haynoi</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.sonpiaz.haynoi</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleName</key>
 	<string>Haynoi</string>
 	<key>CFBundlePackageType</key>

--- a/Sources/Haynoi/Auth/KeychainStorage.swift
+++ b/Sources/Haynoi/Auth/KeychainStorage.swift
@@ -8,7 +8,12 @@ enum KeychainStorage {
         case unexpectedData
     }
 
-    private static let service = "com.sonpiaz.haynoi"
+    // Keyed by the RUNNING bundle id: the release app resolves to the literal
+    // "com.sonpiaz.haynoi" (existing users' items unchanged), while dev builds
+    // (com.sonpiaz.haynoi.dev) get their own namespace — a dev build reading
+    // release-owned items across signing identities is what caused the endless
+    // "enter your login keychain password" prompts (2026-08-30).
+    private static let service = Bundle.main.bundleIdentifier ?? "com.sonpiaz.haynoi"
 
     static func save(_ value: String, for key: String) throws {
         guard let data = value.data(using: .utf8) else {

--- a/project.yml
+++ b/project.yml
@@ -40,10 +40,28 @@ targets:
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         LD_RUNPATH_SEARCH_PATHS: "@executable_path/../Frameworks"
+        # Release identity = exactly what ships (CI re-signs with the same
+        # Developer ID, so local release builds match the released app's TCC
+        # identity). Debug builds get their OWN bundle id + the development
+        # cert: two identities on ONE bundle id made TCC's Accessibility grant
+        # flip-flop every time a Debug build launched (the "grant dies" loop,
+        # 2026-08-30 — TCC stores the granting binary's cert in its designated
+        # requirement). Separate ids = separate TCC records that never fight,
+        # and a Debug launch no longer kills the running production app
+        # (the single-instance guard matches per bundle id).
+        # Developer ID cannot host XCTest anyway: AMFI refuses the test-runner
+        # attach ("test runner hung before establishing connection"), which is
+        # why Debug keeps Apple Development and no hardened runtime.
+        CODE_SIGN_IDENTITY: "Developer ID Application: Affitor LLC (448LBGWBYM)"
+        DEVELOPMENT_TEAM: 448LBGWBYM
         ENABLE_HARDENED_RUNTIME: true
-        CODE_SIGN_IDENTITY: "Apple Development: me.nguyentungson@gmail.com (LC36QSW9KK)"
-        DEVELOPMENT_TEAM: 6WMWJ85DDY
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
+      configs:
+        debug:
+          PRODUCT_BUNDLE_IDENTIFIER: com.sonpiaz.haynoi.dev
+          CODE_SIGN_IDENTITY: "Apple Development: me.nguyentungson@gmail.com (LC36QSW9KK)"
+          DEVELOPMENT_TEAM: 6WMWJ85DDY
+          ENABLE_HARDENED_RUNTIME: false
     entitlements:
       path: Resources/Haynoi.entitlements
       properties:
@@ -63,6 +81,7 @@ targets:
         SWIFT_VERSION: "5.9"
         MACOSX_DEPLOYMENT_TARGET: "14.0"
         GENERATE_INFOPLIST_FILE: true
+        # Tests only run in Debug — development cert (Developer ID can't host XCTest).
         DEVELOPMENT_TEAM: 6WMWJ85DDY
         CODE_SIGN_IDENTITY: "Apple Development: me.nguyentungson@gmail.com (LC36QSW9KK)"
     scheme:


### PR DESCRIPTION
Root cause of the recurring "Accessibility grant dies" report: two signing identities (Apple Development for local builds, Developer ID for releases) shared bundle id com.sonpiaz.haynoi, and TCC binds the grant to the granting binary's cert. Every Debug launch flipped the record.

Fix: Debug = com.sonpiaz.haynoi.dev + development cert + no hardened runtime (Developer ID can't host XCTest — AMFI refuses the attach; verified empirically). Release unchanged: com.sonpiaz.haynoi + Developer ID + hardened runtime (verified built artifact byte-compatible). Keychain service keys off the running bundle id (release resolves to the same literal — zero user impact). Bonus: dev/test launches no longer kill the running production app.

Full suite passed; Release config built and signature-verified locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ