### PR TITLE
feat(learning): per-word scoreboard — fires vs reversals, visibly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to Haynoi are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- **A scoreboard for every learned word.** Each auto-learned fix now shows how
+  many times it was applied and how often you let it stand ("used 12× · 92%
+  kept"), and the Dictionary header sums it up. When Haynoi gets a word wrong
+  after learning it, that counts against the word — visibly.
+
 ## [0.3.9] - 2026-08-29
 
 ### Fixed

--- a/Sources/Haynoi/Settings/SettingsView.swift
+++ b/Sources/Haynoi/Settings/SettingsView.swift
@@ -609,6 +609,32 @@ private struct DictionaryEditor: View {
         entries.filter { $0.source == .learned }.count
     }
 
+    /// Header line under the learning switch: how many words were learned and —
+    /// once rules have actually fired — how well they held up (§F scoreboard).
+    private var learnedSubtitle: String {
+        guard learnedCount > 0 else {
+            return "Haynoi suggests new words when you fix a dictation."
+        }
+        var s = "Haynoi has learned \(learnedCount) word\(learnedCount == 1 ? "" : "s") from you."
+        let sb = PersonalDictionary.shared.learnedScoreboard
+        if sb.fires > 0 {
+            let kept = Int((Double(max(0, sb.fires - sb.recorrections)) / Double(sb.fires) * 100).rounded())
+            s += " Applied \(sb.fires)× · \(kept)% kept."
+        }
+        return s
+    }
+
+    /// Per-rule tally appended to a replacement row: how often it fired, and —
+    /// only once there is counter-evidence — how often the user let it stand.
+    private func usageSuffix(_ entry: DictionaryEntry) -> String {
+        guard entry.fireCount > 0 else { return "" }
+        var s = " · used \(entry.fireCount)×"
+        if entry.recorrectedCount > 0, let rate = entry.keptRate {
+            s += " · \(Int((rate * 100).rounded()))% kept"
+        }
+        return s
+    }
+
     private var canAdd: Bool {
         let r = rightField.trimmingCharacters(in: .whitespacesAndNewlines)
         if r.isEmpty { return false }
@@ -629,9 +655,7 @@ private struct DictionaryEditor: View {
                         Text("Learn from my corrections")
                             .font(.system(size: 13, weight: .medium))
                             .foregroundStyle(Color.obsidianLabel(for: scheme))
-                        Text(learnedCount > 0
-                             ? "Haynoi has learned \(learnedCount) word\(learnedCount == 1 ? "" : "s") from you."
-                             : "Haynoi suggests new words when you fix a dictation.")
+                        Text(learnedSubtitle)
                             .font(.system(size: 11))
                             .foregroundStyle(Color.obsidianLabel3(for: scheme))
                     }
@@ -710,7 +734,7 @@ private struct DictionaryEditor: View {
                                     ? Color.obsidianLabel(for: scheme)
                                     : Color.obsidianLabel3(for: scheme))
                             if entry.kind == .replacement, let wrong = entry.wrong {
-                                Text("\(wrong) → \(entry.right)")
+                                Text("\(wrong) → \(entry.right)\(usageSuffix(entry))")
                                     .font(.system(size: 10, design: .monospaced))
                                     .foregroundStyle(Color.obsidianLabel3(for: scheme))
                             }

--- a/Sources/Haynoi/System/PersonalDictionary.swift
+++ b/Sources/Haynoi/System/PersonalDictionary.swift
@@ -52,6 +52,17 @@ struct DictionaryEntry: Codable, Identifiable, Hashable {
     // v1.1 — explicit "fix that" correction capture (Signal C).
     var confirmations: Int       // explicit "fix that" confirms; gates .learned .replacement activation (>= 2)
     var fireCount: Int           // times this .replacement actually fired (self-heal + §F effectiveness)
+    // v2 scoreboard (§F) — times the user corrected AGAINST this rule after it
+    // fired (the self-heal event). fireCount vs recorrectedCount is the
+    // per-word accuracy ledger: "applied N× · M% kept".
+    var recorrectedCount: Int
+
+    /// Share of this rule's fires the user let stand, 0...1. nil until it has
+    /// fired at least once — no evidence, no claim.
+    var keptRate: Double? {
+        guard fireCount > 0 else { return nil }
+        return Double(max(0, fireCount - recorrectedCount)) / Double(fireCount)
+    }
 
     enum Kind: String, Codable { case term, replacement }
     enum Source: String, Codable { case manual, learned }
@@ -68,7 +79,8 @@ struct DictionaryEntry: Codable, Identifiable, Hashable {
         frequency: Int = 0,
         createdAt: Date = Date(),
         confirmations: Int = 0,
-        fireCount: Int = 0
+        fireCount: Int = 0,
+        recorrectedCount: Int = 0
     ) {
         self.id = id
         self.right = right
@@ -90,6 +102,7 @@ struct DictionaryEntry: Codable, Identifiable, Hashable {
         self.createdAt = createdAt
         self.confirmations = confirmations
         self.fireCount = fireCount
+        self.recorrectedCount = recorrectedCount
     }
 
     // Decode tolerantly — v1 `dictionary.json` files predate `confirmations`/
@@ -110,6 +123,7 @@ struct DictionaryEntry: Codable, Identifiable, Hashable {
         createdAt = try c.decode(Date.self, forKey: .createdAt)
         confirmations = try c.decodeIfPresent(Int.self, forKey: .confirmations) ?? 0
         fireCount = try c.decodeIfPresent(Int.self, forKey: .fireCount) ?? 0
+        recorrectedCount = try c.decodeIfPresent(Int.self, forKey: .recorrectedCount) ?? 0
     }
 
     /// Activation predicate for a `.replacement` rule (§1.2): manual rules are
@@ -288,8 +302,24 @@ final class PersonalDictionary {
                 $0.right.precomposedStringWithCanonicalMapping.caseInsensitiveCompare(r) == .orderedSame
             }) else { return nil }
             entries[idx].enabled = false
+            // Scoreboard (§F): a reversal IS the evidence a fire was wrong.
+            entries[idx].recorrectedCount += 1
             persist()
             return entries[idx].id
+        }
+    }
+
+    /// Aggregate scoreboard across learned `.replacement` rules — total times
+    /// they fired vs. times the user corrected back. Drives the Dictionary
+    /// header's "applied N× · M% kept" and is the internal proof required
+    /// before any "it learns you" marketing claim (v2 Phase 5 §F).
+    var learnedScoreboard: (fires: Int, recorrections: Int) {
+        queue.sync {
+            entries
+                .filter { $0.source == .learned && $0.kind == .replacement }
+                .reduce((fires: 0, recorrections: 0)) {
+                    ($0.fires + $1.fireCount, $0.recorrections + $1.recorrectedCount)
+                }
         }
     }
 

--- a/Tests/CorrectionLearningTests.swift
+++ b/Tests/CorrectionLearningTests.swift
@@ -30,6 +30,7 @@ final class CorrectionLearningTests: XCTestCase {
 
         XCTAssertEqual(entry.confirmations, 0, "v1 file must default confirmations to 0")
         XCTAssertEqual(entry.fireCount, 0, "v1 file must default fireCount to 0")
+        XCTAssertEqual(entry.recorrectedCount, 0, "pre-scoreboard file must default recorrectedCount to 0")
         XCTAssertEqual(entry.right, "Hà Nội")
         XCTAssertEqual(entry.wrong, "Haynoi")
         XCTAssertEqual(entry.frequency, 3)
@@ -154,13 +155,32 @@ final class CorrectionLearningTests: XCTestCase {
         XCTAssertNotNil(upserted)
         XCTAssertNotNil(dict.enabledReplacement(matching: "selfHealX", right: "selfHealY"))
 
-        // User reverses it → disable.
+        // User reverses it → disable AND score the reversal (§F).
         let disabledID = dict.disableMatchingReplacement(wrong: "selfHealX", right: "selfHealY")
         XCTAssertNotNil(disabledID)
         XCTAssertNil(dict.enabledReplacement(matching: "selfHealX", right: "selfHealY"),
                      "disabled rule must no longer be returned as enabled")
+        if let id = disabledID {
+            XCTAssertEqual(dict.entries(withIDs: [id]).first?.recorrectedCount, 1,
+                           "a reversal must land on the rule's scoreboard")
+        }
 
         // Cleanup so the test doesn't pollute the real dictionary.
         if let id = disabledID { dict.delete(id: id) }
+    }
+
+    // MARK: - §F scoreboard: keptRate
+
+    func testKeptRateNeedsEvidence() {
+        let unfired = DictionaryEntry(right: "Y", wrong: "X", kind: .replacement)
+        XCTAssertNil(unfired.keptRate, "no fires → no accuracy claim")
+
+        let scored = DictionaryEntry(right: "Y", wrong: "X", kind: .replacement,
+                                     fireCount: 4, recorrectedCount: 1)
+        XCTAssertEqual(scored.keptRate, 0.75)
+
+        let overReversed = DictionaryEntry(right: "Y", wrong: "X", kind: .replacement,
+                                           fireCount: 1, recorrectedCount: 3)
+        XCTAssertEqual(overReversed.keptRate, 0, "rate clamps at 0, never negative")
     }
 }


### PR DESCRIPTION
Closes the last gap in the correction-learning methodology (v2 Phase 5 §F): the app now keeps a per-word ledger — how many times each learned fix was APPLIED (fireCount, existed) and how many times the user corrected BACK against it (recorrectedCount, new; incremented by the existing self-heal detection). `keptRate` = evidence-based accuracy per rule, nil until a rule has fired.

UI: replacement rows show `wrong → right · used 12× · 92% kept` (kept% appears only once there is counter-evidence); the Dictionary header sums learned rules into "Applied N× · M% kept."

Old dictionary.json files decode tolerantly (new field defaults 0). Full suite passed, incl. new keptRate + self-heal-scores-the-reversal tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ