### PR TITLE
fix(stt): a 402 is only 'out of words' when it really is the user's quota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **When our servers have a problem, Haynoi now says so** — instead of telling
+  you that you're out of words, or signing you out. A provider-side hiccup is
+  labeled as ours, your quota and sign-in are left alone, and the message asks
+  you to simply try again.
+
 ### Added
 - **A scoreboard for every learned word.** Each auto-learned fix now shows how
   many times it was applied and how often you let it stand ("used 12× · 92%

--- a/Sources/Haynoi/Transcription/STTProvider.swift
+++ b/Sources/Haynoi/Transcription/STTProvider.swift
@@ -382,8 +382,19 @@ enum STTProvider {
                 NotificationHelper.postSessionExpired()
                 throw STTError.sessionExpired
             case 402:
-                NSLog("[Haynoi] 402 from proxy — monthly word quota exhausted")
-                throw STTError.outOfCredits
+                // Only OUR server's quota 402 carries code "quota_exhausted".
+                // Any other 402 on this path is an operator-side failure that
+                // slipped through untranslated — never blame the user's word
+                // limit for it (the 2026-08 misattribution incident). The
+                // server now translates upstream 401/402/403 to 502; this is
+                // the client-side belt to that suspender.
+                if Self.isQuotaExhausted(data) {
+                    NSLog("[Haynoi] 402 from proxy — word quota exhausted")
+                    throw STTError.outOfCredits
+                }
+                NSLog("[Haynoi] 402 without quota_exhausted — treating as upstream fault")
+                throw STTError.serverError(
+                    "Our transcription service is having a moment — this isn't your word limit. Please try again shortly.")
             case 429:
                 NSLog("[Haynoi] Rate limited by proxy")
                 throw STTError.rateLimited
@@ -398,6 +409,18 @@ enum STTProvider {
             NSLog("[Haynoi] Transport error: %@", urlErr.localizedDescription)
             throw STTError.noConnection
         }
+    }
+
+    /// True only for the server's OWN quota-exhausted envelope:
+    /// {"error":{"code":"quota_exhausted", ...}}. Anything else on a 402 is an
+    /// operator-side failure wearing the wrong status. Pure — unit-tested.
+    static func isQuotaExhausted(_ data: Data) -> Bool {
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let errorObj = json["error"] as? [String: Any],
+              let code = errorObj["code"] as? String else {
+            return false
+        }
+        return code == "quota_exhausted"
     }
 
     /// Extracts the human-readable message from a proxy error envelope.

--- a/Tests/CorrectionPassTests.swift
+++ b/Tests/CorrectionPassTests.swift
@@ -62,6 +62,25 @@ final class CorrectionPassTests: XCTestCase {
             needsRewrite: false, logprobs: [-0.1, -2.2], hasGrounding: true))
     }
 
+    // MARK: - 402 attribution: whose fault is a 402?
+
+    func testQuotaExhaustedBodyIsRecognized() {
+        let ours = #"{"error":{"code":"quota_exhausted","message":"Weekly words limit reached."}}"#
+        XCTAssertTrue(STTProvider.isQuotaExhausted(Data(ours.utf8)))
+    }
+
+    func testUpstreamShapedBodiesAreNotBlamedOnTheUser() {
+        for body in [
+            #"{"error":{"message":"Insufficient balance","type":"billing_error"}}"#,  // upstream 402, no code
+            #"{"error":{"code":"upstream_unavailable","message":"..."}}"#,
+            #"not json at all"#,
+            #"{}"#,
+        ] {
+            XCTAssertFalse(STTProvider.isQuotaExhausted(Data(body.utf8)),
+                           "must never read as the user's quota: \(body)")
+        }
+    }
+
     func testCorrectionPromptComposesUnderGrounding() {
         let system = STTProvider.rewriteSystemPrompt(
             base: STTProvider.correctionPassPrompt,


### PR DESCRIPTION
Client half of the 402 misattribution fix (P0-2 in the product audit). Server half is live: the kit proxy now translates upstream 401/402/403 to a 502 `upstream_unavailable` (an operator-side failure must never read as the user's quota or session), surfaces the FUP soft warning as an `X-Usage-Warning` header, and the usage-watcher cron sends a once-per-period fair-use nudge to unlimited tiers (fairUseUnits was dead config — and was a monthly number compared against weekly usage; now 30k/week).

Client: `isQuotaExhausted(body)` gates `.outOfCredits` on the server's own `quota_exhausted` code; anything else 402-shaped shows "this isn't your word limit". Tests cover both shapes + non-JSON bodies. Full suite passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ