### PR TITLE
chore(release): prep 0.3.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to Haynoi are documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.3.10] - 2026-09-01
 
 ### Fixed
 - **When our servers have a problem, Haynoi now says so** — instead of telling

--- a/project.yml
+++ b/project.yml
@@ -33,8 +33,8 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.sonpiaz.haynoi
         PRODUCT_NAME: Haynoi
-        MARKETING_VERSION: "0.3.9"
-        CURRENT_PROJECT_VERSION: "31"
+        MARKETING_VERSION: "0.3.10"
+        CURRENT_PROJECT_VERSION: "32"
         INFOPLIST_FILE: Resources/Info.plist
         CODE_SIGN_ENTITLEMENTS: Resources/Haynoi.entitlements
         SWIFT_VERSION: "5.9"

--- a/site/changelog/index.html
+++ b/site/changelog/index.html
@@ -88,6 +88,18 @@
   <div class="log-wrap">
     <article class="release">
       <div class="release-head">
+        <span class="release-version">0.3.10</span>
+        <span class="release-date">September 1, 2026</span>
+      </div>
+      <p class="release-tagline">Honest errors, scored learning.</p>
+      <ul>
+        <li>When our servers have a problem, Haynoi now says so — instead of telling you that you're out of words, or signing you out.</li>
+        <li>Every learned word now carries a scoreboard: how many times it was applied and how often you let it stand — visible per word and summed up in the Dictionary tab.</li>
+      </ul>
+    </article>
+
+    <article class="release">
+      <div class="release-head">
         <span class="release-version">0.3.9</span>
         <span class="release-date">August 29, 2026</span>
       </div>

--- a/version.env
+++ b/version.env
@@ -8,5 +8,5 @@
 #   - MARKETING_VERSION: semver-ish (MAJOR.MINOR.PATCH), user-visible
 #   - BUILD_NUMBER: monotonic integer, must increase every release
 
-MARKETING_VERSION=0.3.9
-BUILD_NUMBER=31
+MARKETING_VERSION=0.3.10
+BUILD_NUMBER=32


### PR DESCRIPTION
Stamps CHANGELOG [Unreleased] → [0.3.10] - 2026-09-01 (402 attribution fix + per-word learning scoreboard), bumps 0.3.10/build 32, adds the site changelog entry. Tag v0.3.10 follows the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K5HfmTk6x1B1pFTio8aSUJ